### PR TITLE
ci: add linting job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: Server CI
+
+on:  # yamllint disable-line rule:truthy
+  pull_request: {}
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint-go:
+    name: Lint code
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Determine golang-ci version
+        id: golangci_version
+        run: |
+          echo "version=$(go mod edit -json hack/tools/golang-ci/go.mod | \
+            jq '.Require | map(select(.Path == "github.com/golangci/golangci-lint"))[].Version')" \
+            >> $GITHUB_OUTPUT
+
+      - name: Lint with golang-ci
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ steps.golangci_version.version }}
+          working-directory: server

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+linters:
+  disable:
+    - exhaustruct
+  presets:
+    - bugs
+    - performance
+    - test

--- a/cache.go
+++ b/cache.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -67,7 +68,7 @@ func NewCache(ctx context.Context, l *slog.Logger) (*Cache, error) {
 		}
 	}()
 	if !c.WaitForCacheSync(ctx) {
-		return nil, fmt.Errorf("error starting the cache")
+		return nil, errors.New("error starting the cache")
 	}
 
 	return &Cache{

--- a/http_server.go
+++ b/http_server.go
@@ -47,6 +47,7 @@ func (s *NamespaceListerServer) Start(ctx context.Context) error {
 		sctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 
+		//nolint:contextcheck
 		if err := s.Shutdown(sctx); err != nil {
 			s.logger.Error("error gracefully shutting down the HTTP server", "error", err)
 			os.Exit(1)


### PR DESCRIPTION
This adds a job in github actions to lint go code using golangci-lint. It adds a configuration to enable more checks than the default, so some linter checks we would want (such as gosec) won't need to be specified with a separate job.