### PR TITLE
Add yamllint checks

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,5 @@
+---
+extends: relaxed
+rules:
+  line-length:
+    max: 100

--- a/acceptance/config/proxy/kustomization.yaml
+++ b/acceptance/config/proxy/kustomization.yaml
@@ -6,6 +6,6 @@ resources:
 - proxy.yaml
 namespace: namespace-lister
 configMapGenerator:
-  - name: namespace-lister-proxy
-    files:
-      - nginx.conf
+- name: namespace-lister-proxy
+  files:
+  - nginx.conf

--- a/acceptance/config/proxy/proxy.yaml
+++ b/acceptance/config/proxy/proxy.yaml
@@ -24,12 +24,12 @@ spec:
       containers:
       - image: openresty/openresty:1.25.3.1-0-jammy
         name: nginx-120
-        command: 
-          - "/usr/local/openresty/bin/openresty"
-          - "-g"
-          - "daemon off;"
-          - -c
-          - /etc/nginx/nginx.conf
+        command:
+        - "/usr/local/openresty/bin/openresty"
+        - "-g"
+        - "daemon off;"
+        - -c
+        - /etc/nginx/nginx.conf
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -65,50 +65,50 @@ spec:
             cpu: 30m
             memory: 128Mi
         volumeMounts:
-          - mountPath: /etc/nginx/nginx.conf
-            subPath: nginx.conf
-            name: namespace-lister-proxy
-            readOnly: true
-          - name: logs
-            mountPath: /var/log/nginx
-          - name: nginx-tmp
-            mountPath: /var/lib/nginx/tmp
-          - name: run
-            mountPath: /run
-          - name: serving-cert
-            mountPath: /mnt
-          - name: nginx-generated-config
-            mountPath: /mnt/nginx-generated-config
-          - name: openresty
-            mountPath: /var/run/openresty
+        - mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+          name: namespace-lister-proxy
+          readOnly: true
+        - name: logs
+          mountPath: /var/log/nginx
+        - name: nginx-tmp
+          mountPath: /var/lib/nginx/tmp
+        - name: run
+          mountPath: /run
+        - name: serving-cert
+          mountPath: /mnt
+        - name: nginx-generated-config
+          mountPath: /mnt/nginx-generated-config
+        - name: openresty
+          mountPath: /var/run/openresty
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1001
       volumes:
-        - configMap:
-            defaultMode: 420
-            name: namespace-lister-proxy
-            items:
-              - key: nginx.conf
-                path: nginx.conf 
+      - configMap:
+          defaultMode: 420
           name: namespace-lister-proxy
-        - name: logs
-          emptyDir: {}
-        - name: nginx-tmp
-          emptyDir: {}
-        - name: run
-          emptyDir: {}
-        - name: serving-cert
-          secret:
-            secretName: serving-cert
-        - name: nginx-generated-config
-          emptyDir: {}
-        - name: api-token
-          secret:
-            secretName: namespace-lister-proxy
-        - name: openresty
-          emptyDir: {}
+          items:
+          - key: nginx.conf
+            path: nginx.conf
+        name: namespace-lister-proxy
+      - name: logs
+        emptyDir: {}
+      - name: nginx-tmp
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
+      - name: nginx-generated-config
+        emptyDir: {}
+      - name: api-token
+        secret:
+          secretName: namespace-lister-proxy
+      - name: openresty
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service
@@ -120,18 +120,18 @@ spec:
   type: NodePort
   internalTrafficPolicy: Cluster
   ipFamilies:
-    - IPv4
+  - IPv4
   ipFamilyPolicy: SingleStack
   ports:
-    - name: web
-      port: 8888
-      nodePort: 30010
-      protocol: TCP
-      targetPort: web
-    - name: web-tls
-      port: 9443
-      nodePort: 30011      
-      protocol: TCP
-      targetPort: web-tls
+  - name: web
+    port: 8888
+    nodePort: 30010
+    protocol: TCP
+    targetPort: web
+  - name: web-tls
+    port: 9443
+    nodePort: 30011
+    protocol: TCP
+    targetPort: web-tls
   selector:
     app: namespace-lister-proxy

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -35,14 +35,14 @@ spec:
             cpu: 10m
             memory: 64Mi
         ports:
-          - containerPort: 8080
-            name: http  
+        - containerPort: 8080
+          name: http
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
       volumes:
       - name: "traefik-plugin-storage"
         emptyDir:

--- a/config/rbac.yaml
+++ b/config/rbac.yaml
@@ -9,10 +9,10 @@ kind: ClusterRoleBinding
 metadata:
   name: namespace-lister-authorizer
 subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: namespace-lister
-    namespace: namespace-lister
+- apiGroup: ""
+  kind: ServiceAccount
+  name: namespace-lister
+  namespace: namespace-lister
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,14 +23,14 @@ kind: ClusterRole
 metadata:
   name: namespace-lister-authorizer
 rules:
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: 
-      - "rbac.authorization.k8s.io"
-    resources:
-      - clusterroles
-      - clusterrolebindings
-      - roles
-      - rolebindings
-    verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Add a config for [yamllint].  This config is derived from the `relaxed` preset, but allows for lines up to 100 characters in length instead of the default of 80.

[yamllint]: https://github.com/adrienverge/yamllint