### PR TITLE
Add renovate config

### DIFF
--- a/acceptance/test/dumb-proxy/config/proxy/kustomization.yaml
+++ b/acceptance/test/dumb-proxy/config/proxy/kustomization.yaml
@@ -9,3 +9,6 @@ configMapGenerator:
 - name: namespace-lister-proxy
   files:
   - nginx.conf
+images:
+- name: openresty/openresty
+  newTag: 1.25.3.1-0-jammy

--- a/acceptance/test/dumb-proxy/config/proxy/proxy.yaml
+++ b/acceptance/test/dumb-proxy/config/proxy/proxy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       serviceAccountName: namespace-lister-proxy
       containers:
-      - image: openresty/openresty:1.25.3.1-0-jammy
+      - image: openresty/openresty:latest
         name: nginx-120
         command:
         - "/usr/local/openresty/bin/openresty"

--- a/acceptance/test/smart-proxy/config/proxy-auth/kustomization.yaml
+++ b/acceptance/test/smart-proxy/config/proxy-auth/kustomization.yaml
@@ -9,3 +9,8 @@ configMapGenerator:
 - name: namespace-lister-proxy-auth
   files:
   - nginx.conf
+images:
+- name: registry.access.redhat.com/ubi9/ubi
+  digest: sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072
+- name: openresty/openresty
+  newTag: 1.25.3.1-0-jammy

--- a/acceptance/test/smart-proxy/config/proxy-auth/proxy.yaml
+++ b/acceptance/test/smart-proxy/config/proxy-auth/proxy.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: namespace-lister-proxy-auth
       initContainers:
       - name: add-sva-token-to-nginx-config
-        image: registry.access.redhat.com/ubi9/ubi@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072
+        image: registry.access.redhat.com/ubi9/ubi:latest
         command:
         - sh
         - -c
@@ -54,7 +54,7 @@ spec:
             cpu: 10m
             memory: 64Mi
       containers:
-      - image: openresty/openresty:1.25.3.1-0-jammy
+      - image: openresty/openresty:latest
         name: nginx-120
         command:
         - "/usr/local/openresty/bin/openresty"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+    "extends": [
+        "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+    ],
+    "enabledManagers": [
+        "docker",
+        "go",
+        "kustomize",
+    ],
+    "go": {
+        "pinDigests": false
+    },
+}


### PR DESCRIPTION
Add a renovate config to enable automated dependency upgrades.  Enables updates for the following components:
- go.mod dependencies
- images referenced in container manifests
- images referenced in kustomize manifests