### PR TITLE
Allow TLS enablement

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -19,7 +19,9 @@ spec:
       #   runAsNonRoot: true
       serviceAccountName: namespace-lister
       containers:
-      - image: namespace-lister:latest
+      - args:
+        - -enable-tls=false
+        image: namespace-lister:latest
         name: namespace-lister
         imagePullPolicy: IfNotPresent
         env:


### PR DESCRIPTION
This PR allows TLS to be enabled via the addition of three command-line arguments:
```
  -cert-path string
        Path to TLS certificate store.
  -enable-tls
        Toggle tls enablement (default true)
  -key-path string
        Path to TLS private key.
```

TLS is enabled by default, but disable it during testing to allow for easier debugging.