### PR TITLE
Use https in acceptance tests

### DIFF
--- a/acceptance/test/dumb-proxy/config/proxy/nginx.conf
+++ b/acceptance/test/dumb-proxy/config/proxy/nginx.conf
@@ -53,7 +53,7 @@ http {
         location ~* /api/v1/namespaces(/?)$ {
             # namespace-lister endpoint
             rewrite ^/(.*)/$ /$1 permanent;
-            proxy_pass http://namespace-lister.namespace-lister.svc.cluster.local:12000;
+            proxy_pass https://namespace-lister.namespace-lister.svc.cluster.local:12000;
             proxy_read_timeout 1m;
         }
 

--- a/acceptance/test/smart-proxy/config/proxy-auth/nginx.conf
+++ b/acceptance/test/smart-proxy/config/proxy-auth/nginx.conf
@@ -53,7 +53,7 @@ http {
         location ~* /api/v1/namespaces(/?)$ {
             # namespace-lister endpoint
             rewrite ^/(.*)/$ /$1 permanent;
-            proxy_pass http://namespace-lister.namespace-lister.svc.cluster.local:12000;
+            proxy_pass https://namespace-lister.namespace-lister.svc.cluster.local:12000;
             proxy_read_timeout 1m;
         }
 

--- a/config/certificate.yaml
+++ b/config/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: namespace-lister-cert
+spec:
+  dnsNames:
+  - namespace-lister.namespace-lister.svc
+  - namespace-lister.namespace-lister.svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: self-signed-cluster-issuer
+  secretName: namespace-lister-cert

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -20,7 +20,9 @@ spec:
       serviceAccountName: namespace-lister
       containers:
       - args:
-        - -enable-tls=false
+        - -enable-tls
+        - -cert-path=/var/tls/tls.crt
+        - -key-path=/var/tls/tls.key
         image: namespace-lister:latest
         name: namespace-lister
         imagePullPolicy: IfNotPresent
@@ -45,4 +47,12 @@ spec:
           capabilities:
             drop:
             - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
       terminationGracePeriodSeconds: 60
+      volumes:
+      - name: tls
+        secret:
+          secretName: namespace-lister-cert

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,8 +1,40 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- certificate.yaml
 - deployment.yaml
 - service.yaml
 - namespace.yaml
 - rbac.yaml
 namespace: namespace-lister
+replacements:
+- source:
+    kind: Service
+    name: namespace-lister
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: cert-manager.io
+      version: v1
+      kind: Certificate
+      name: namespace-lister-cert
+    fieldPaths:
+    - spec.dnsNames.*
+    options:
+      delimiter: "."
+      index: 0
+- source:
+    kind: Service
+    name: namespace-lister
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      group: cert-manager.io
+      version: v1
+      kind: Certificate
+      name: namespace-lister-cert
+    fieldPaths:
+    - spec.dnsNames.*
+    options:
+      delimiter: "."
+      index: 1


### PR DESCRIPTION
This PR configures namespace-lister to use https during acceptance tests.  Certificates are provided by cert-manager.