### PR TITLE
yamllint: increase allowed line length

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -4,4 +4,4 @@ ignore:
 - .tekton/
 rules:
   line-length:
-    max: 100
+    max: 120


### PR DESCRIPTION
We've been getting a warning about a too-long line in ci.yaml:149.  I wasn't able to come up with a way of splitting this line that was pleasing to my eyes, so increase the allowed line length instead.