### PR TITLE
cache: store namespace names instead of metadata

### DIFF
--- a/mocks/rest_interface.go
+++ b/mocks/rest_interface.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -182,15 +183,15 @@ func (m *MockFakeSubjectNamespacesLister) EXPECT() *MockFakeSubjectNamespacesLis
 }
 
 // List mocks base method.
-func (m *MockFakeSubjectNamespacesLister) List(subject v10.Subject) []v1.Namespace {
+func (m *MockFakeSubjectNamespacesLister) List(arg0 context.Context, arg1 v10.Subject) []v1.Namespace {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", subject)
+	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].([]v1.Namespace)
 	return ret0
 }
 
 // List indicates an expected call of List.
-func (mr *MockFakeSubjectNamespacesListerMockRecorder) List(subject any) *gomock.Call {
+func (mr *MockFakeSubjectNamespacesListerMockRecorder) List(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockFakeSubjectNamespacesLister)(nil).List), subject)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockFakeSubjectNamespacesLister)(nil).List), arg0, arg1)
 }

--- a/namespacelister_for_subject.go
+++ b/namespacelister_for_subject.go
@@ -12,7 +12,7 @@ import (
 var _ NamespaceLister = &subjectNamespaceLister{}
 
 type SubjectNamespacesLister interface {
-	List(subject rbacv1.Subject) []corev1.Namespace
+	List(context.Context, rbacv1.Subject) []corev1.Namespace
 }
 
 type subjectNamespaceLister struct {
@@ -27,7 +27,7 @@ func NewNamespaceListerForSubject(subjectNamespacesLister SubjectNamespacesListe
 
 func (c *subjectNamespaceLister) ListNamespaces(ctx context.Context, username string) (*corev1.NamespaceList, error) {
 	sub := c.parseUsername(username)
-	nn := c.subjectNamespacesLister.List(sub)
+	nn := c.subjectNamespacesLister.List(ctx, sub)
 
 	// list all namespaces
 	return &corev1.NamespaceList{

--- a/namespacelister_for_subject_test.go
+++ b/namespacelister_for_subject_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Subjectnamespaceslister", func() {
 		// set expectation
 		subjectNamespacesLister.EXPECT().
 			List(
+				ctx,
 				rbacv1.Subject{
 					Kind:      "ServiceAccount",
 					Name:      "myserviceaccount",
@@ -67,6 +68,7 @@ var _ = Describe("Subjectnamespaceslister", func() {
 		// set expectation
 		subjectNamespacesLister.EXPECT().
 			List(
+				ctx,
 				rbacv1.Subject{
 					APIGroup: rbacv1.GroupName,
 					Kind:     "User",

--- a/pkg/auth/cache/access_cache.go
+++ b/pkg/auth/cache/access_cache.go
@@ -3,29 +3,29 @@ package cache
 import (
 	"sync/atomic"
 
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // stores data
 type AccessCache struct {
-	data atomic.Pointer[map[rbacv1.Subject][]corev1.Namespace]
+	data atomic.Pointer[map[rbacv1.Subject]sets.Set[string]]
 }
 
 func NewAccessCache() *AccessCache {
 	return &AccessCache{
-		data: atomic.Pointer[map[rbacv1.Subject][]corev1.Namespace]{},
+		data: atomic.Pointer[map[rbacv1.Subject]sets.Set[string]]{},
 	}
 }
 
-func (c *AccessCache) List(subject rbacv1.Subject) []corev1.Namespace {
+func (c *AccessCache) List(subject rbacv1.Subject) []string {
 	m := c.data.Load()
 	if m == nil {
 		return nil
 	}
-	return (*m)[subject]
+	return (*m)[subject].UnsortedList()
 }
 
-func (c *AccessCache) Restock(data *map[rbacv1.Subject][]corev1.Namespace) {
+func (c *AccessCache) Restock(data *map[rbacv1.Subject]sets.Set[string]) {
 	c.data.Store(data)
 }

--- a/pkg/auth/cache/access_cache_test.go
+++ b/pkg/auth/cache/access_cache_test.go
@@ -4,23 +4,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/konflux-ci/namespace-lister/pkg/auth/cache"
 )
 
 var _ = Describe("AuthCache", func() {
-	enn := []corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "myns",
-				Labels:      map[string]string{"key": "value"},
-				Annotations: map[string]string{"key": "value"},
-			},
-		},
-	}
+	enn := sets.New("myns")
 
 	It("returns an empty result if it is empty", func() {
 		// given
@@ -37,12 +28,12 @@ var _ = Describe("AuthCache", func() {
 		// given
 		sub := rbacv1.Subject{Kind: "User", Name: "myuser"}
 		c := cache.NewAccessCache()
-		c.Restock(&map[rbacv1.Subject][]corev1.Namespace{sub: enn})
+		c.Restock(&map[rbacv1.Subject]sets.Set[string]{sub: enn})
 
 		// when
 		nn := c.List(sub)
 
 		// then
-		Expect(nn).To(BeEquivalentTo(enn))
+		Expect(nn).To(BeEquivalentTo(enn.UnsortedList()))
 	})
 })


### PR DESCRIPTION
Instead of caching namespace metadata, we can instead only cache the namespaces' names and pull their definitions from the client cache. This saves some memory at the expense of a minor increase in response latency (benchmarks indicated on the order of a few extra milliseconds).