### PR TITLE
ignore ClusterRoleBindings

### DIFF
--- a/acceptance/test/dumb-proxy/features/list.feature
+++ b/acceptance/test/dumb-proxy/features/list.feature
@@ -2,4 +2,10 @@ Feature: List Namespaces
 
   Scenario: ServiceAccount list namespace
     Given ServiceAccount has access to "10" namespaces
+    Given 10 tenant namespaces exist
     Then the ServiceAccount can retrieve only the namespaces they have access to
+
+  Scenario: ClusterRoleBindings are ignored
+    Given the ServiceAccount has Cluster-scoped get permission on namespaces
+    Given 10 tenant namespaces exist
+    Then the ServiceAccount retrieves no namespaces

--- a/acceptance/test/smart-proxy/features/list.feature
+++ b/acceptance/test/smart-proxy/features/list.feature
@@ -7,3 +7,8 @@ Feature: List Namespaces
   Scenario: user not authenticated
     Given User is not authenticated
     Then  the User request is rejected with unauthorized error
+
+  Scenario: ClusterRoleBindings are ignored
+    Given the ServiceAccount has Cluster-scoped get permission on namespaces
+    Given 10 tenant namespaces exist
+    Then the ServiceAccount retrieves no namespaces

--- a/namespacelister_with_authorizer_test.go
+++ b/namespacelister_with_authorizer_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Namespacelister", func() {
 			rbacv1.RoleBindingList{},
 			corev1.NamespaceList{Items: []corev1.Namespace{}},
 		),
-		Entry("returns the namespace if both the clusterrole and a valid clusterrolebinding exist",
+		Entry("returns no namespaces if both the clusterrole and a valid clusterrolebinding exist",
 			corev1.NamespaceList{Items: []corev1.Namespace{
 				{ObjectMeta: metav1.ObjectMeta{Name: "myns-1"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "myns-2"}},
@@ -121,9 +121,7 @@ var _ = Describe("Namespacelister", func() {
 			}},
 			rbacv1.RoleList{},
 			rbacv1.RoleBindingList{},
-			corev1.NamespaceList{Items: []corev1.Namespace{
-				{ObjectMeta: metav1.ObjectMeta{Name: "myns-1", ResourceVersion: "999"}},
-			}},
+			corev1.NamespaceList{Items: []corev1.Namespace{}},
 		),
 		Entry("returns no namespace if the role exists but no rolebinding",
 			corev1.NamespaceList{Items: []corev1.Namespace{

--- a/performance_test.go
+++ b/performance_test.go
@@ -196,8 +196,8 @@ var _ = Describe("Authorizing requests", Serial, Ordered, func() {
 		httpListingStats := experiment.GetStats("http listing")
 		medianDuration := httpListingStats.DurationFor(gmeasure.StatMedian)
 
-		// and assert that it hasn't changed much from ~100ms
-		Expect(medianDuration).To(BeNumerically("~", 100*time.Millisecond, 70*time.Millisecond))
+		// and assert that it is below a threshold
+		Expect(medianDuration).To(BeNumerically("<", 100*time.Millisecond))
 	})
 
 	It("efficiently authorize on a huge environment with cached accesses", Serial, Label("perf"), func(ctx context.Context) {
@@ -270,15 +270,14 @@ var _ = Describe("Authorizing requests", Serial, Ordered, func() {
 		utilruntime.Must(err)
 
 		// check cache is correctly populated with
-		// more than 5000 subjects
-		// and more than 9000 total namespaces
+		// the expected number of subjects and namespaces
 		cacheData := unsafeGetPrivateCacheData(c.AccessCache)
-		Expect(len(cacheData)).To(BeNumerically(">", 5000))
+		Expect(cacheData).To(HaveLen(5501))
 		cachedNsSubPairs := 0
 		for _, v := range cacheData {
 			cachedNsSubPairs += len(v)
 		}
-		Expect(cachedNsSubPairs).To(BeNumerically(">", 9000))
+		Expect(cachedNsSubPairs).To(Equal(5800))
 
 		// we sample a function repeatedly to get a statistically significant set of measurements
 		experiment.Sample(func(idx int) {

--- a/rbac_authorizer.go
+++ b/rbac_authorizer.go
@@ -81,15 +81,5 @@ func (r *CRAuthRetriever) GetClusterRole(name string) (*rbacv1.ClusterRole, erro
 
 // ListClusterRoleBindings retrieves ClusterRoleBindings
 func (r *CRAuthRetriever) ListClusterRoleBindings() ([]*rbacv1.ClusterRoleBinding, error) {
-	rbb := rbacv1.ClusterRoleBindingList{}
-	if err := r.cli.List(r.ctx, &rbb); err != nil {
-		return nil, err
-	}
-	r.l.Debug("listing clusterrolebindings", "clusterrolebindings", rbb)
-
-	rbbp := make([]*rbacv1.ClusterRoleBinding, len(rbb.Items))
-	for i, rb := range rbb.Items {
-		rbbp[i] = rb.DeepCopy()
-	}
-	return rbbp, nil
+	return make([]*rbacv1.ClusterRoleBinding, 0), nil
 }

--- a/rbac_authorizer_test.go
+++ b/rbac_authorizer_test.go
@@ -18,9 +18,7 @@ import (
 )
 
 var _ = Describe("CRAuthRetriever", func() {
-	var (
-		logger *slog.Logger
-	)
+	var logger *slog.Logger
 
 	BeforeEach(func() {
 		logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
@@ -91,6 +89,6 @@ var _ = Describe("CRAuthRetriever", func() {
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
-		Expect(acrbl).To(ConsistOf(crbl))
+		Expect(acrbl).To(BeEmpty())
 	})
 })

--- a/resource_cache.go
+++ b/resource_cache.go
@@ -116,24 +116,18 @@ func BuildAndStartResourceCache(ctx context.Context, cfg *cacheConfig) (cache.Ca
 		&corev1.Namespace{},
 		&rbacv1.RoleBinding{},
 		&rbacv1.ClusterRole{},
-		&rbacv1.ClusterRoleBinding{},
 		&rbacv1.Role{},
 	}
 	c, err := cache.New(cfg.restConfig, cache.Options{
 		Scheme:                       s,
 		DefaultUnsafeDisableDeepCopy: ptr(true),
+		ReaderFailOnMissingInformer:  true,
 		ByObject: map[client.Object]cache.ByObject{
 			&corev1.Namespace{}: {
 				Label: cfg.namespacesLabelSector,
 			},
 			&rbacv1.ClusterRole{}: {
 				Transform: trimClusterRole(),
-			},
-			&rbacv1.ClusterRoleBinding{}: {
-				Transform: mergeTransformFunc(
-					cache.TransformStripManagedFields(),
-					trimAnnotations(),
-				),
 			},
 			&rbacv1.RoleBinding{}: {
 				Transform: mergeTransformFunc(


### PR DESCRIPTION
The namespace-lister should not consider ClusterRoleBindings when calculating the access to a namespace.
Indeed, the namespace-lister requires the access to be granted from inside the namespace.

Signed-off-by: Francesco Ilario <filario@redhat.com>
