### PR TITLE
metrics: expose number of cached namespaces per subject

### DIFF
--- a/pkg/auth/cache/metrics_accesscache_test.go
+++ b/pkg/auth/cache/metrics_accesscache_test.go
@@ -77,9 +77,10 @@ func getVector(metrics cache.AccessCacheMetrics, name string) (model.Vector, err
 	return expfmt.ExtractSamples(&expfmt.DecodeOptions{Timestamp: model.Now()}, mf)
 }
 
-var _ = DescribeTable("MetricsAccessCache/SuccessfulSynch", func(data cache.AccessData, err error, subs, subNsPairs int) {
+var _ = DescribeTable("MetricsAccessCache/SuccessfulSynch", func(data cache.AccessData, err error, subNsPairs int) {
 	// given
 	metrics := cache.NewAccessCacheMetrics()
+	subs := len(data)
 
 	// when
 	metrics.CollectSynchMetrics(data, err)
@@ -108,15 +109,15 @@ var _ = DescribeTable("MetricsAccessCache/SuccessfulSynch", func(data cache.Acce
 		Expect(vec[0].Value).To(Equal(model.SampleValue(subNsPairs)))
 	}
 },
-	Entry("nil data", nil, nil, 0, 0),
-	Entry("empty data", cache.AccessData{}, nil, 0, 0),
+	Entry("nil data", nil, nil, 0),
+	Entry("empty data", cache.AccessData{}, nil, 0),
 	Entry("1 subject", cache.AccessData{
 		rbacv1.Subject{}: []corev1.Namespace{},
-	}, nil, 1, 0),
+	}, nil, 0),
 	Entry("2 subjects - 10 Namespaces", cache.AccessData{
 		rbacv1.Subject{Name: "1"}: []corev1.Namespace{{}, {}, {}, {}, {}},
 		rbacv1.Subject{Name: "2"}: []corev1.Namespace{{}, {}, {}, {}, {}},
-	}, nil, 2, 10),
+	}, nil, 10),
 )
 
 var _ = Describe("MetricsAccessCache/TimeRequests", func() {

--- a/pkg/auth/cache/metrics_accesscache_test.go
+++ b/pkg/auth/cache/metrics_accesscache_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 const (
-	resourcesRequestsMetricFullname     = "namespace_lister_accesscache_resource_requests_total"
-	timeRequestsMetricFullname          = "namespace_lister_accesscache_time_requests_total"
-	syncMetricFullname                  = "namespace_lister_accesscache_synch_op_total"
-	subjectNamespacePairsMetricFullname = "namespace_lister_accesscache_subject_namespace_pairs"
-	subjectsMetricFullname              = "namespace_lister_accesscache_subjects"
+	resourcesRequestsMetricFullname     string = "namespace_lister_accesscache_resource_requests_total"
+	timeRequestsMetricFullname          string = "namespace_lister_accesscache_time_requests_total"
+	syncMetricFullname                  string = "namespace_lister_accesscache_synch_op_total"
+	subjectNamespacePairsMetricFullname string = "namespace_lister_accesscache_subject_namespace_pairs"
+	subjectsMetricFullname              string = "namespace_lister_accesscache_subjects"
 )
 
 var _ = Describe("MetricsAccessCache/FailedSynch", func() {


### PR DESCRIPTION
This series exposes the number of namespaces a subject has in our cache.  This allows us to have better metrics on how our cache is being used in live deployments.

By adding these metrics, we can add more insightful metrics to our dashboards.  For instance, we can now tell if there are subjects in our cache who have a lot of cached namespaces, indicating broad access across the cluster.  We can also use these metrics to get an idea of how large our cache is, by summing across all metrics and ignoring labels.

This series also does a little refactoring of the unit tests associated with the cache.