### PR TITLE
inject a logger copy in request's context

### DIFF
--- a/http_api_server.go
+++ b/http_api_server.go
@@ -29,7 +29,7 @@ func NewAPIServer(l *slog.Logger, ar authenticator.Request, lister NamespaceList
 	h := http.NewServeMux()
 	h.Handle(patternGetNamespaces,
 		addMetricsMiddleware(reg,
-			addInjectLoggerMiddleware(l,
+			addInjectLoggerMiddleware(*l,
 				addLogRequestMiddleware(
 					addAuthnMiddleware(ar,
 						NewListNamespacesHandler(lister))))))

--- a/http_api_server_middlewares.go
+++ b/http_api_server_middlewares.go
@@ -13,9 +13,9 @@ import (
 
 // addInjectLoggerMiddleware injects the provided logger in each request context.
 // It also generates and sets a correlation ID for each request.
-func addInjectLoggerMiddleware(l *slog.Logger, next http.Handler) http.HandlerFunc {
+func addInjectLoggerMiddleware(ol slog.Logger, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		l = l.With("correlation-id", uuid.NewUUID())
+		l := ol.With("correlation-id", uuid.NewUUID())
 		ctx := setLoggerIntoContext(r.Context(), l)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}


### PR DESCRIPTION
This change copies the logger that's injected in the request context before injecting it.
Without this change each request is adding a `correlationId` field to the global logger.

Signed-off-by: Francesco Ilario <filario@redhat.com>
