### PR TITLE
add healthz and readyz endpoints

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -35,6 +35,18 @@ spec:
         #   value: "X-User"
         # - name: CACHE_NAMESPACE_LABELSELECTOR
         #   value: 'konflux.dev/type=user'
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8080
+            scheme: HTTPS
         resources:
           limits:
             cpu: 500m

--- a/http_api_server.go
+++ b/http_api_server.go
@@ -14,6 +14,8 @@ import (
 
 const (
 	patternGetNamespaces string = "GET /api/v1/namespaces"
+	patternHealthz       string = "GET /healthz"
+	patternReadyz        string = "GET /readyz"
 )
 
 // APIServer is an HTTP server that serves the List Namespace endpoint
@@ -21,6 +23,10 @@ type APIServer struct {
 	*http.Server
 	useTLS  bool
 	tlsOpts []func(*tls.Config)
+}
+
+func healthz(response http.ResponseWriter, _ *http.Request) {
+	response.WriteHeader(http.StatusOK)
 }
 
 // NewAPIServer builds a new APIServer
@@ -33,6 +39,9 @@ func NewAPIServer(l *slog.Logger, ar authenticator.Request, lister NamespaceList
 				addLogRequestMiddleware(
 					addAuthnMiddleware(ar,
 						NewListNamespacesHandler(lister))))))
+
+	h.HandleFunc(patternHealthz, healthz)
+	h.HandleFunc(patternReadyz, healthz)
 
 	return &APIServer{
 		Server: &http.Server{


### PR DESCRIPTION
Add /healthz and /readyz endpoints as probes for kubernetes to talk to.

For now, readyz and healthz do the same thing, but we may want to have readyz have more checks in the future, such as ensuring we can talk to apiserver and we have sufficient privileges to run.