### PR TITLE
remove irrelevant check on clusterroles

### DIFF
--- a/resource_cache.go
+++ b/resource_cache.go
@@ -69,11 +69,6 @@ func trimClusterRole() toolscache.TransformFunc {
 				return nil, fmt.Errorf("error caching ClusterRole: expected a ClusterRole received %T", i)
 			}
 
-			// can't define at this time if it will relate to namespaces, so let's keep it
-			if cr.AggregationRule != nil && cr.AggregationRule.ClusterRoleSelectors != nil {
-				return i, nil
-			}
-
 			cr.Rules = filterNamespacesRelatedPolicyRules(cr.Rules)
 			if len(cr.Rules) == 0 {
 				return nil, nil


### PR DESCRIPTION
the `rules` field will be populated by the controller, so we can threat them as regular clusterroles

Signed-off-by: Francesco Ilario <filario@redhat.com>
