### PR TITLE
add synch timeout

### DIFF
--- a/pkg/auth/cache/synchronized_access_cache.go
+++ b/pkg/auth/cache/synchronized_access_cache.go
@@ -93,6 +93,12 @@ func (s *SynchronizedAccessCache) synch(ctx context.Context) (AccessData, error)
 
 	// get subjects for each namespace
 	for _, ns := range nn.Items {
+		// interrupt if context elapsed
+		if err := ctx.Err(); err != nil {
+			s.logger.Warn("cache restocking: could not complete calculate access data process", "error", err)
+			return AccessData{}, ctx.Err()
+		}
+
 		ar := authorizer.AttributesRecord{
 			Verb:            "get",
 			Resource:        "namespaces",
@@ -107,7 +113,7 @@ func (s *SynchronizedAccessCache) synch(ctx context.Context) (AccessData, error)
 		if err != nil {
 			// do not forward the error as it should be due
 			// to cache evicted (cluster)roles
-			s.logger.Debug("cache restocking: error caculating allowed subjects", "error", err)
+			s.logger.Debug("cache restocking: error caculating allowed subjects", "namespace", ns.GetName(), "error", err)
 		}
 
 		// remove duplicates from allowed subjects

--- a/pkg/auth/cache/synchronized_access_cache.go
+++ b/pkg/auth/cache/synchronized_access_cache.go
@@ -40,6 +40,7 @@ type SynchronizedAccessCache struct {
 	logger           *slog.Logger
 	syncErrorHandler func(context.Context, error, *SynchronizedAccessCache)
 	resyncPeriod     time.Duration
+	synchTimeout     time.Duration
 
 	metrics AccessCacheMetrics
 }
@@ -68,8 +69,12 @@ func (s *SynchronizedAccessCache) Synch(ctx context.Context) error {
 	}
 	defer s.synchronizing.Store(false)
 
+	// add timeout for the synch operation
+	sctx, cancel := context.WithTimeout(ctx, s.synchTimeout)
+	defer cancel()
+
 	// execute synch operation
-	cacheData, err := s.synch(ctx)
+	cacheData, err := s.synch(sctx)
 
 	// collect metrics wrt to synch operation result
 	s.metrics.CollectSynchMetrics(cacheData, err)

--- a/pkg/auth/cache/synchronized_access_cache_test.go
+++ b/pkg/auth/cache/synchronized_access_cache_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -69,6 +70,48 @@ var _ = Describe("SynchronizedAccessCache", func() {
 			Times(1)
 		nsc := cache.NewSynchronizedAccessCache(subjectLocator, namespaceLister, cache.CacheSynchronizerOptions{
 			SynchTimeout: 1 * time.Second,
+		})
+
+		// when
+		Expect(nsc.Synch(ctx)).
+			// then
+			To(MatchError("context deadline exceeded"))
+	})
+
+	It("will return empty data if timed-out", Label("aaa"), func(ctx context.Context) {
+		// given
+		namespaceLister := mocks.NewMockClientReader(ctrl)
+		namespaceLister.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, nn *corev1.NamespaceList, opts ...client.ListOption) error {
+				(&corev1.NamespaceList{
+					Items: []corev1.Namespace{
+						{ObjectMeta: metav1.ObjectMeta{Name: "myns-1"}},
+						{ObjectMeta: metav1.ObjectMeta{Name: "myns-2"}},
+						{ObjectMeta: metav1.ObjectMeta{Name: "myns-3"}},
+					},
+				}).DeepCopyInto(nn)
+				return nil
+			}).
+			Times(1)
+
+			// subjectLocator will reply fast the first time it's called and cause a timeout the second time
+		hasBeenCalledOnce := false
+		subjectLocator.EXPECT().
+			AllowedSubjects(gomock.Any()).
+			DoAndReturn(func(attributes authorizer.Attributes) ([]rbacv1.Subject, error) {
+				if !hasBeenCalledOnce {
+					hasBeenCalledOnce = true
+					return []rbacv1.Subject{userSubject}, nil
+				}
+
+				time.Sleep(100 * time.Millisecond)
+				return []rbacv1.Subject{userSubject}, nil
+			}).
+			Times(2)
+
+		nsc := cache.NewSynchronizedAccessCache(subjectLocator, namespaceLister, cache.CacheSynchronizerOptions{
+			SynchTimeout: 50 * time.Millisecond,
 		})
 
 		// when

--- a/pkg/auth/cache/synchronized_access_cache_test.go
+++ b/pkg/auth/cache/synchronized_access_cache_test.go
@@ -97,10 +97,8 @@ var _ = Describe("SynchronizedAccessCache", func() {
 
 		subjectLocator.EXPECT().
 			AllowedSubjects(gomock.Any()).
-			DoAndReturn(func(attributes authorizer.Attributes) ([]rbacv1.Subject, error) {
-				// reply fast the first time
-				return []rbacv1.Subject{userSubject}, nil
-			}).
+			// reply fast the first time
+			Return([]rbacv1.Subject{userSubject}, nil).
 			DoAndReturn(func(attributes authorizer.Attributes) ([]rbacv1.Subject, error) {
 				// cause a timeout the second time
 				time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
This PR introduces a timeout to the synch operation.

It can be set from configuration. If not, the maximum between 1min and `resyncPeriod-1min` is used.
