### PR TITLE
add support for X-Correlation-ID header

### DIFF
--- a/http_api_server.go
+++ b/http_api_server.go
@@ -36,9 +36,10 @@ func NewAPIServer(l *slog.Logger, ar authenticator.Request, lister NamespaceList
 	h.Handle(patternGetNamespaces,
 		addMetricsMiddleware(reg,
 			addInjectLoggerMiddleware(*l,
-				addAuthnMiddleware(ar,
-					addLogRequestMiddleware(
-						NewListNamespacesHandler(lister))))))
+				addLogCorrelationIDMiddleware(
+					addAuthnMiddleware(ar,
+						addLogRequestMiddleware(
+							NewListNamespacesHandler(lister)))))))
 
 	h.HandleFunc(patternHealthz, healthz)
 	h.HandleFunc(patternReadyz, healthz)


### PR DESCRIPTION
If the X-Correlation-ID Header is set, use its value. Otherwise, generate a new value for the CorrelationID.

Eventually we may want to add support for [TraceContext](https://www.w3.org/TR/trace-context/) instead of CorrelationID.

Signed-off-by: Francesco Ilario <filario@redhat.com>
