### PR TITLE
ci: pull go version from go.mod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,15 +104,10 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Determine Go version
-        id: go_version
-        run: |
-          echo "version=$(go mod edit -json | jq -r '.Go')" >> $GITHUB_OUTPUT
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ steps.go_version.outputs.version }}
+          go-version-file: go.mod
 
       - name: Ensure go.mod is tidy
         env:
@@ -139,10 +134,10 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Determine Go version
-        id: go_version
-        run: |
-          echo "version=$(go mod edit -json ./hack/tools/golang-ci/go.mod | jq -r '.Go')" >> $GITHUB_OUTPUT
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: hack/tools/golang-ci/go.mod
 
       - name: Determine golang-ci version
         id: golangci_version
@@ -150,11 +145,6 @@ jobs:
           echo "version=$(go mod edit -json hack/tools/golang-ci/go.mod | \
             jq -r '.Require | map(select(.Path == "github.com/golangci/golangci-lint"))[].Version')" \
             >> $GITHUB_OUTPUT
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ steps.go_version.outputs.version }}
 
       - name: Lint with golang-ci
         uses: golangci/golangci-lint-action@v7


### PR DESCRIPTION
We can tell the setup-go action to pull the go version directly from go.mod.  Use that rather than doing awkward go.mod parsing ourselves.