### PR TITLE
add acceptance test for group

### DIFF
--- a/acceptance/test/smart-proxy/features/list.feature
+++ b/acceptance/test/smart-proxy/features/list.feature
@@ -6,8 +6,8 @@ Feature: List Namespaces
 
   Scenario: user with groups list namespaces
     Given User has access to "10" namespaces
-    Given Group "mygroup" has access to "10" namespaces
-    Given User is part of group "mygroup"
+    Given Group "mygroup-1" has access to "10" namespaces
+    Given User is part of group "mygroup-1"
     Then the User can retrieve the namespaces they and their groups have access to
 
   Scenario: user not authenticated
@@ -18,3 +18,9 @@ Feature: List Namespaces
     Given the ServiceAccount has Cluster-scoped get permission on namespaces
     Given 10 tenant namespaces exist
     Then the ServiceAccount retrieves no namespaces
+
+  Scenario: user has no namespaces, authenticated group does
+    Given User has access to "0" namespaces
+    Given Group "mygroup-2" has access to "10" namespaces
+    Given User is part of group "mygroup-2"
+    Then the User can retrieve the namespaces they and their groups have access to


### PR DESCRIPTION
we want to test users can retrieve group-bound namespaces
even though they have no direct access to any namespace

Signed-off-by: Francesco Ilario <filario@redhat.com>
