### PR TITLE
ci: add dependabot configuration for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Our github actions workflows don't see automatic updates, which means they can get out-of-date.  Add automation to ensure these will automatically get PRs to bump out-of-date actions.

Unfortunately, while renovate supports github actions, it's not enabled in konflux's mintmaker deployment[^1].  Until that changes, dependabot is the only option for enabling this workflow.

[^1]: https://github.com/konflux-ci/mintmaker/blob/0f7d127a004b465c529df942ecd5a8cbcef0c242/config/renovate/renovate.json#L26-L71