### PR TITLE
execute e2e tests on the latest 3 k8s versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,17 +75,36 @@ jobs:
         run: |
           GINKGO="go run github.com/onsi/ginkgo/v2/ginkgo --github-output" make test-perf
 
+  get-kind-node-image-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.versions }}
+    steps:
+      - name: Fetch and Filter Versions
+        id: set-matrix
+        run: |
+          VERSIONS=$(skopeo list-tags docker://kindest/node | jq -c '
+            .Tags
+            | [ .[] | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) ]
+            | sort_by(split(".")[0:3] | map(ltrimstr("v") | tonumber))
+            | group_by(split(".")[1])
+            | map(last)
+            | .[-3:]
+          ')
+          echo "Identified versions: ${VERSIONS}"
+          echo "versions=${VERSIONS}" >> $GITHUB_OUTPUT
+
   acceptance:
     name: Run acceptance tests
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
+    needs: get-kind-node-image-versions
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - proxy: dumb-proxy
-          - proxy: smart-proxy
+        proxy: [ "dumb-proxy", "smart-proxy" ]
+        kubernetes: ${{ fromJson(needs.get-kind-node-image-versions.outputs.matrix) }}
 
     steps:
       - name: Checkout Git Repository
@@ -107,6 +126,7 @@ jobs:
           IMAGE_BUILDER: podman
           IMG: konflux-ci.dev/namespace-lister:pr-${{ github.event.pull_request.number }}
           ENABLE_COVERAGE: "true"
+          KIND_NODE_IMG: ${{ matrix.kubernetes }}
         run: |
           echo "##[group] Preparing environment"
             make -C "acceptance/test/${{ matrix.proxy }}" prepare

--- a/acceptance/make/common.mk
+++ b/acceptance/make/common.mk
@@ -29,9 +29,12 @@ lint: ## Run go linter.
 image-build:
 	$(MAKE) -C $(ROOT_DIR)/.. image-build
 
+KIND_NODE_IMG ?=
+KIND_NODE_IMG_FLAG = $(if $(KIND_NODE_IMG),--image "kindest/node:$(KIND_NODE_IMG)",)
+
 .PHONY: kind-create
 kind-create:
-	$(KIND) create cluster --name "$(KIND_CLUSTER_NAME)" --config kind-config.yaml
+	$(KIND) create cluster --name "$(KIND_CLUSTER_NAME)" --config kind-config.yaml $(KIND_NODE_IMG_FLAG)
 
 .PHONY: kind-load-image
 kind-load-image:


### PR DESCRIPTION
This change allows us to test in CI if latest 3 available kubernetes versions are supported.

Signed-off-by: Francesco Ilario <filario@redhat.com>
Assisted-by: Gemini

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
