### PR TITLE
do not log headers

### DIFF
--- a/http_api_server_middlewares.go
+++ b/http_api_server_middlewares.go
@@ -58,7 +58,7 @@ func addAuthnMiddleware(ar authenticator.Request, next http.Handler) http.Handle
 		case err != nil: // error contacting the APIServer for authenticating the request
 			w.WriteHeader(http.StatusUnauthorized)
 			l := getLoggerFromContext(r.Context())
-			l.Error("error authenticating request", "error", err, "request-headers", r.Header)
+			l.Error("error authenticating request", "error", err)
 			return
 
 		case !ok: // request could not be authenticated


### PR DESCRIPTION
we don't have full control on what's inside the Headers, we should not log them all.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
