### PR TITLE
Add dependency PR triage workflow

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,22 @@
+name: Auto-merge approved dependency PRs
+
+on:
+  check_suite:
+    types: [completed]
+
+jobs:
+  auto-merge:
+    name: Merge if all checks pass
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: konflux-ci/deptriage@main
+        with:
+          command: merge
+          pr-number: "0"
+          head-sha: ${{ github.event.check_suite.head_sha }}

--- a/.github/workflows/dep-triage.yaml
+++ b/.github/workflows/dep-triage.yaml
@@ -1,0 +1,33 @@
+name: Dependency Impact Analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: dep-triage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: Triage dependency PR
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'red-hat-konflux[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: konflux-ci/deptriage@main
+        with:
+          command: both
+          pr-number: ${{ github.event.pull_request.number }}
+          api-key: ${{ secrets.GEMINI_API_KEY }}
+          llm-provider: gemini
+          auto-approve: 'true'
+          auto-merge: 'true'


### PR DESCRIPTION
Introduce `deptriage` for automated dependency PR classification, AI impact analysis, and auto-merge of eligible patches.

This PR is part of the testing/refining process of this tool, so the definitive form can change depending on the findings and feedback.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Contributes to: KFLUXINFRA-3320