### PR TITLE
fix: Use GitHub App token for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -15,8 +15,14 @@ jobs:
       statuses: read
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_ID }}
+          private-key: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_PRIVATE_KEY }}
       - uses: konflux-ci/deptriage@main
         with:
           command: merge
           pr-number: "0"
           head-sha: ${{ github.event.check_suite.head_sha }}
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The default GITHUB_TOKEN is treated as the same actor as the bot that pushed the PR, triggering the "require approval from someone other than the last pusher" branch protection rule. Use a GitHub App token instead so the merger is a different identity.