### PR TITLE
feat: add cache acceptance test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: kubernetes-sigs/kwok@main
         with:
-          command: 'kwokctl'
+          command: "kwokctl"
 
       - name: Set up kwokctl
         uses: kubernetes-sigs/kwok@main
@@ -111,7 +111,7 @@ jobs:
           echo "##[group] Preparing environment"
             make -C "acceptance/test/${{ matrix.proxy }}" prepare
           echo "##[endgroup]"
-          echo "##[group] Running tests"
+          echo "##[group] Running tests (${{ matrix.proxy }})"
             make -C "acceptance/test/${{ matrix.proxy }}" test
           echo "##[endgroup]"
 
@@ -143,7 +143,6 @@ jobs:
           flags: e2e-tests
           directory: coverage-output
           fail_ci_if_error: false
-
 
   go-tidy:
     name: Tidy go mod

--- a/acceptance/pkg/suite/steps.go
+++ b/acceptance/pkg/suite/steps.go
@@ -63,17 +63,8 @@ func NTenantNamespacesExist(ctx context.Context, limit int) (context.Context, er
 	}
 
 	for i := range limit {
-		n := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("run-%s-%d-%d", run, tn, i),
-				Labels: map[string]string{
-					"konflux.ci/type":           "user",
-					"namespace-lister/scope":    "acceptance-tests",
-					"namespace-lister/test-run": run,
-				},
-			},
-		}
-		if err := cli.Create(ctx, &n); err != nil {
+		n := newTestNamespace(fmt.Sprintf("run-%s-%d-%d", run, tn, i), run)
+		if err := cli.Create(ctx, n); err != nil {
 			return ctx, err
 		}
 	}
@@ -183,36 +174,18 @@ func subjectHasAccessToNNamespaces(ctx context.Context, subject rbacv1.Subject, 
 	// create namespaces
 	nn := tcontext.Namespaces(ctx)
 	for i := range number {
-		n := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("run-%s-%s-%d", run, strings.ReplaceAll(subject.Name, ":", "-"), i),
-				Labels: map[string]string{
-					"konflux.ci/type":           "user",
-					"namespace-lister/scope":    "acceptance-tests",
-					"namespace-lister/test-run": run,
-				},
-			},
-		}
-		if err := cli.Create(ctx, &n); err != nil {
+		name := fmt.Sprintf("run-%s-%s-%d", run, strings.ReplaceAll(subject.Name, ":", "-"), i)
+		n := newTestNamespace(name, run)
+		if err := cli.Create(ctx, n); err != nil {
 			return ctx, err
 		}
 
-		if err := cli.Create(ctx, &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("run-%s-%s-%d", run, strings.ReplaceAll(subject.Name, ":", "-"), i),
-				Namespace: fmt.Sprintf("run-%s-%s-%d", run, strings.ReplaceAll(subject.Name, ":", "-"), i),
-			},
-			RoleRef: rbacv1.RoleRef{
-				Kind:     "ClusterRole",
-				Name:     "namespace-get",
-				APIGroup: rbacv1.GroupName,
-			},
-			Subjects: []rbacv1.Subject{subject},
-		}); err != nil {
+		rb := newAccessRoleBinding(name, name, subject)
+		if err := cli.Create(ctx, rb); err != nil {
 			return ctx, err
 		}
 
-		nn = append(nn, n)
+		nn = append(nn, *n)
 	}
 
 	return tcontext.WithNamespaces(ctx, nn), nil

--- a/acceptance/pkg/suite/steps_cache.go
+++ b/acceptance/pkg/suite/steps_cache.go
@@ -1,0 +1,234 @@
+package suite
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"slices"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	tcontext "github.com/konflux-ci/namespace-lister/acceptance/pkg/context"
+	arest "github.com/konflux-ci/namespace-lister/acceptance/pkg/rest"
+)
+
+func InjectCacheSteps(ctx *godog.ScenarioContext) {
+	ctx.Given(`^a namespace "([^"]*)" exists without access for the current user$`, aNamespaceExistsWithoutAccess)
+	ctx.When(`^a new namespace "([^"]*)" is created with access for the current user$`, aNewNamespaceIsCreatedWithAccess)
+	ctx.When(`^the namespace "([^"]*)" is deleted$`, theNamespaceIsDeleted)
+	ctx.When(`^a RoleBinding granting access is added in namespace "([^"]*)"$`, aRoleBindingIsAddedInNamespace)
+	ctx.When(`^the RoleBinding is removed from namespace "([^"]*)"$`, theRoleBindingIsRemovedFromNamespace)
+	ctx.When(`^"(\d+)" namespaces with access are created and "(\d+)" existing namespaces are deleted$`, bulkNamespaceChanges)
+
+	ctx.Then(`^the user can see namespace "([^"]*)" in the list$`, theUserCanSeeNamespaceInTheList)
+	ctx.Then(`^the user cannot see namespace "([^"]*)" in the list$`, theUserCannotSeeNamespaceInTheList)
+}
+
+func aNamespaceExistsWithoutAccess(ctx context.Context, nsName string) (context.Context, error) {
+	run := tcontext.RunId(ctx)
+	user := tcontext.User(ctx)
+	fullName := fmt.Sprintf("run-%s-%s", run, nsName)
+
+	cli, err := arest.BuildDefaultHostClient()
+	if err != nil {
+		return ctx, err
+	}
+
+	ns := newTestNamespace(fullName, run)
+	if err := cli.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+		return ctx, err
+	}
+
+	// ensure no leftover RoleBinding from a previous run grants access
+	rb := newAccessRoleBinding(fmt.Sprintf("run-%s-%s-access", run, nsName), fullName, user.AsSubject())
+	if err := cli.Delete(ctx, rb); err != nil && !errors.IsNotFound(err) {
+		return ctx, err
+	}
+
+	return ctx, nil
+}
+
+func aNewNamespaceIsCreatedWithAccess(ctx context.Context, nsName string) (context.Context, error) {
+	run := tcontext.RunId(ctx)
+	user := tcontext.User(ctx)
+	fullName := fmt.Sprintf("run-%s-%s", run, nsName)
+
+	cli, err := arest.BuildDefaultHostClient()
+	if err != nil {
+		return ctx, err
+	}
+
+	ns := newTestNamespace(fullName, run)
+	if err := cli.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+		return ctx, err
+	}
+
+	rb := newAccessRoleBinding(fmt.Sprintf("run-%s-%s-access", run, nsName), fullName, user.AsSubject())
+	if err := cli.Create(ctx, rb); err != nil && !errors.IsAlreadyExists(err) {
+		return ctx, err
+	}
+
+	nn := tcontext.Namespaces(ctx)
+	nn = append(nn, *ns)
+	return tcontext.WithNamespaces(ctx, nn), nil
+}
+
+func theNamespaceIsDeleted(ctx context.Context, nsName string) (context.Context, error) {
+	run := tcontext.RunId(ctx)
+	fullName := fmt.Sprintf("run-%s-%s", run, nsName)
+
+	cli, err := arest.BuildDefaultHostClient()
+	if err != nil {
+		return ctx, err
+	}
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: fullName}}
+	if err := cli.Delete(ctx, ns); err != nil && !errors.IsNotFound(err) {
+		return ctx, err
+	}
+
+	nn := tcontext.Namespaces(ctx)
+	nn = slices.DeleteFunc(nn, func(n corev1.Namespace) bool {
+		return n.Name == fullName
+	})
+	return tcontext.WithNamespaces(ctx, nn), nil
+}
+
+func aRoleBindingIsAddedInNamespace(ctx context.Context, nsName string) (context.Context, error) {
+	run := tcontext.RunId(ctx)
+	user := tcontext.User(ctx)
+	fullName := fmt.Sprintf("run-%s-%s", run, nsName)
+
+	cli, err := arest.BuildDefaultHostClient()
+	if err != nil {
+		return ctx, err
+	}
+
+	rb := newAccessRoleBinding(fmt.Sprintf("run-%s-%s-access", run, nsName), fullName, user.AsSubject())
+	if err := cli.Create(ctx, rb); err != nil && !errors.IsAlreadyExists(err) {
+		return ctx, err
+	}
+
+	// track the namespace as expected
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: fullName}}
+	nn := tcontext.Namespaces(ctx)
+	if !slices.ContainsFunc(nn, func(n corev1.Namespace) bool { return n.Name == fullName }) {
+		nn = append(nn, ns)
+	}
+	return tcontext.WithNamespaces(ctx, nn), nil
+}
+
+func theRoleBindingIsRemovedFromNamespace(ctx context.Context, nsName string) (context.Context, error) {
+	run := tcontext.RunId(ctx)
+	fullName := fmt.Sprintf("run-%s-%s", run, nsName)
+
+	cli, err := arest.BuildDefaultHostClient()
+	if err != nil {
+		return ctx, err
+	}
+
+	user := tcontext.User(ctx)
+	rb := newAccessRoleBinding(fmt.Sprintf("run-%s-%s-access", run, nsName), fullName, user.AsSubject())
+	if err := cli.Delete(ctx, rb); err != nil && !errors.IsNotFound(err) {
+		return ctx, err
+	}
+
+	nn := tcontext.Namespaces(ctx)
+	nn = slices.DeleteFunc(nn, func(n corev1.Namespace) bool {
+		return n.Name == fullName
+	})
+	return tcontext.WithNamespaces(ctx, nn), nil
+}
+
+func bulkNamespaceChanges(ctx context.Context, toCreate, toDelete int) (context.Context, error) {
+	run := tcontext.RunId(ctx)
+	user := tcontext.User(ctx)
+
+	cli, err := arest.BuildDefaultHostClient()
+	if err != nil {
+		return ctx, err
+	}
+
+	nn := tcontext.Namespaces(ctx)
+	if toDelete > len(nn) {
+		return ctx, fmt.Errorf("requested deletion of %d namespaces but only %d are tracked", toDelete, len(nn))
+	}
+
+	// delete existing namespaces
+	for i := range toDelete {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nn[i].Name}}
+		if err := cli.Delete(ctx, ns); err != nil && !errors.IsNotFound(err) {
+			return ctx, err
+		}
+	}
+	nn = nn[toDelete:]
+
+	// create new namespaces
+	for i := range toCreate {
+		name := fmt.Sprintf("run-%s-bulk-%d", run, i)
+		ns := newTestNamespace(name, run)
+		if err := cli.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+			return ctx, err
+		}
+
+		rb := newAccessRoleBinding(fmt.Sprintf("run-%s-bulk-%d-access", run, i), name, user.AsSubject())
+		if err := cli.Create(ctx, rb); err != nil && !errors.IsAlreadyExists(err) {
+			return ctx, err
+		}
+
+		nn = append(nn, *ns)
+	}
+
+	return tcontext.WithNamespaces(ctx, nn), nil
+}
+
+func theUserCanSeeNamespaceInTheList(ctx context.Context, nsName string) (context.Context, error) {
+	run := tcontext.RunId(ctx)
+	fullName := fmt.Sprintf("run-%s-%s", run, nsName)
+
+	cli, err := tcontext.InvokeBuildUserClientFunc(ctx)
+	if err != nil {
+		return ctx, err
+	}
+
+	return ctx, wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		ann := corev1.NamespaceList{}
+		if err := cli.List(ctx, &ann); err != nil {
+			log.Printf("error listing namespaces: %v", err)
+			return false, nil
+		}
+
+		return slices.ContainsFunc(ann.Items, func(n corev1.Namespace) bool {
+			return n.Name == fullName
+		}), nil
+	})
+}
+
+func theUserCannotSeeNamespaceInTheList(ctx context.Context, nsName string) (context.Context, error) {
+	run := tcontext.RunId(ctx)
+	fullName := fmt.Sprintf("run-%s-%s", run, nsName)
+
+	cli, err := tcontext.InvokeBuildUserClientFunc(ctx)
+	if err != nil {
+		return ctx, err
+	}
+
+	return ctx, wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		ann := corev1.NamespaceList{}
+		if err := cli.List(ctx, &ann); err != nil {
+			log.Printf("error listing namespaces: %v", err)
+			return false, nil
+		}
+
+		return !slices.ContainsFunc(ann.Items, func(n corev1.Namespace) bool {
+			return n.Name == fullName
+		}), nil
+	})
+}
+

--- a/acceptance/pkg/suite/steps_helpers.go
+++ b/acceptance/pkg/suite/steps_helpers.go
@@ -1,0 +1,35 @@
+package suite
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestNamespace(name, run string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"konflux.ci/type":           "user",
+				"namespace-lister/scope":    "acceptance-tests",
+				"namespace-lister/test-run": run,
+			},
+		},
+	}
+}
+
+func newAccessRoleBinding(name, namespace string, subject rbacv1.Subject) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "namespace-get",
+			APIGroup: rbacv1.GroupName,
+		},
+		Subjects: []rbacv1.Subject{subject},
+	}
+}

--- a/acceptance/test/dumb-proxy/features/cache.feature
+++ b/acceptance/test/dumb-proxy/features/cache.feature
@@ -1,0 +1,34 @@
+@cache @serial
+Feature: Cache Consistency
+
+  Scenario: Namespace created after startup becomes visible
+    Given ServiceAccount has access to "3" namespaces
+    Then the ServiceAccount can retrieve only the namespaces they have access to
+    When a new namespace "dynamic-ns" is created with access for the current user
+    Then the user can see namespace "dynamic-ns" in the list
+
+  Scenario: Namespace deleted while service is running becomes invisible
+    Given ServiceAccount has access to "3" namespaces
+    When a new namespace "to-delete" is created with access for the current user
+    Then the user can see namespace "to-delete" in the list
+    When the namespace "to-delete" is deleted
+    Then the user cannot see namespace "to-delete" in the list
+
+  Scenario: RoleBinding added grants access to existing namespace
+    Given a namespace "to-grant" exists without access for the current user
+    Then the user cannot see namespace "to-grant" in the list
+    When a RoleBinding granting access is added in namespace "to-grant"
+    Then the user can see namespace "to-grant" in the list
+
+  Scenario: RoleBinding removed revokes access
+    Given ServiceAccount has access to "3" namespaces
+    When a new namespace "to-revoke" is created with access for the current user
+    Then the user can see namespace "to-revoke" in the list
+    When the RoleBinding is removed from namespace "to-revoke"
+    Then the user cannot see namespace "to-revoke" in the list
+
+  Scenario: Bulk concurrent namespace and RBAC changes
+    Given ServiceAccount has access to "5" namespaces
+    Then the ServiceAccount can retrieve only the namespaces they have access to
+    When "7" namespaces with access are created and "5" existing namespaces are deleted
+    Then the ServiceAccount can retrieve only the namespaces they have access to

--- a/acceptance/test/dumb-proxy/step_test.go
+++ b/acceptance/test/dumb-proxy/step_test.go
@@ -10,4 +10,5 @@ func InjectSteps(ctx *godog.ScenarioContext) {
 	suite.InjectSteps(ctx)
 	suite.InjectHealthSteps(ctx)
 	suite.InjectMetricsSteps(ctx)
+	suite.InjectCacheSteps(ctx)
 }

--- a/acceptance/test/smart-proxy/features/cache.feature
+++ b/acceptance/test/smart-proxy/features/cache.feature
@@ -1,0 +1,34 @@
+@cache @serial
+Feature: Cache Consistency
+
+  Scenario: Namespace created after startup becomes visible
+    Given User has access to "3" namespaces
+    Then the User can retrieve only the namespaces they have access to
+    When a new namespace "dynamic-ns" is created with access for the current user
+    Then the user can see namespace "dynamic-ns" in the list
+
+  Scenario: Namespace deleted while service is running becomes invisible
+    Given User has access to "3" namespaces
+    When a new namespace "to-delete" is created with access for the current user
+    Then the user can see namespace "to-delete" in the list
+    When the namespace "to-delete" is deleted
+    Then the user cannot see namespace "to-delete" in the list
+
+  Scenario: RoleBinding added grants access to existing namespace
+    Given a namespace "to-grant" exists without access for the current user
+    Then the user cannot see namespace "to-grant" in the list
+    When a RoleBinding granting access is added in namespace "to-grant"
+    Then the user can see namespace "to-grant" in the list
+
+  Scenario: RoleBinding removed revokes access
+    Given User has access to "3" namespaces
+    When a new namespace "to-revoke" is created with access for the current user
+    Then the user can see namespace "to-revoke" in the list
+    When the RoleBinding is removed from namespace "to-revoke"
+    Then the user cannot see namespace "to-revoke" in the list
+
+  Scenario: Bulk concurrent namespace and RBAC changes
+    Given User has access to "5" namespaces
+    Then the User can retrieve only the namespaces they have access to
+    When "7" namespaces with access are created and "5" existing namespaces are deleted
+    Then the User can retrieve only the namespaces they have access to

--- a/acceptance/test/smart-proxy/step_test.go
+++ b/acceptance/test/smart-proxy/step_test.go
@@ -15,6 +15,7 @@ func InjectSteps(ctx *godog.ScenarioContext) {
 	suite.InjectSteps(ctx)
 	suite.InjectHealthSteps(ctx)
 	suite.InjectMetricsSteps(ctx)
+	suite.InjectCacheSteps(ctx)
 
 	ctx.Given("^User is not authenticated$", userIsNotAuthenticated)
 }


### PR DESCRIPTION
Add BDD tests for namespace cache behavior:
- Namespace created after startup becomes visible
- Namespace deleted while service is running becomes invisible
- RoleBinding added grants access to existing namespace
- RoleBinding removed revokes access
- Bulk concurrent namespace and RBAC changes

Contributes to: KFLUXINFRA-3243