### PR TITLE
Add unit tests for resource cache transforms and access cache startup

### DIFF
--- a/access_cache_startup.go
+++ b/access_cache_startup.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"context"
-	"os"
-	"time"
 
-	"github.com/konflux-ci/namespace-lister/internal/constants"
 	"github.com/konflux-ci/namespace-lister/internal/log"
+	"github.com/konflux-ci/namespace-lister/internal/resourcecache"
 	"github.com/konflux-ci/namespace-lister/pkg/auth/cache"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -20,7 +18,7 @@ import (
 // buildAndStartSynchronizedAccessCache builds a SynchronizedAccessCache.
 // It registers handlers on events on resources that will trigger an AccessCache synchronization.
 func buildAndStartSynchronizedAccessCache(ctx context.Context, resourceCache crcache.Cache, registry prometheus.Registerer) (*cache.SynchronizedAccessCache, error) {
-	acm, err := buildAndRegisterAccessCacheMetrics(registry)
+	acm, err := resourcecache.BuildAndRegisterAccessCacheMetrics(registry)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +29,7 @@ func buildAndStartSynchronizedAccessCache(ctx context.Context, resourceCache crc
 		sae,
 		resourceCache, cache.CacheSynchronizerOptions{
 			Logger:       log.GetLoggerFromContext(ctx),
-			ResyncPeriod: getResyncPeriodFromEnvOrZero(ctx),
+			ResyncPeriod: resourcecache.GetResyncPeriodFromEnvOrZero(ctx),
 			Metrics:      acm,
 		},
 	)
@@ -62,32 +60,3 @@ func buildAndStartSynchronizedAccessCache(ctx context.Context, resourceCache crc
 	return synchCache, nil
 }
 
-func buildAndRegisterAccessCacheMetrics(registry prometheus.Registerer) (cache.AccessCacheMetrics, error) {
-	// if a registry has not been provided, let's proceed without metrics
-	if registry == nil {
-		return nil, nil
-	}
-
-	// build and register the AccessCacheMetrics
-	accessCacheMetrics := cache.NewAccessCacheMetrics()
-	if err := registry.Register(accessCacheMetrics); err != nil {
-		return nil, err
-	}
-	return accessCacheMetrics, nil
-}
-
-// getResyncPeriodFromEnvOrZero retrieves AccessCache's ResyncPeriod from environment variables.
-// If the environment variable is not set it returns the zero value.
-func getResyncPeriodFromEnvOrZero(ctx context.Context) time.Duration {
-	var zero time.Duration
-	rps, ok := os.LookupEnv(constants.EnvCacheResyncPeriod)
-	if !ok {
-		return zero
-	}
-	rp, err := time.ParseDuration(rps)
-	if err != nil {
-		log.GetLoggerFromContext(ctx).Warn("can not parse duration from environment variable", "error", err)
-		return zero
-	}
-	return rp
-}

--- a/internal/resourcecache/access_cache.go
+++ b/internal/resourcecache/access_cache.go
@@ -1,0 +1,40 @@
+package resourcecache
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/konflux-ci/namespace-lister/internal/constants"
+	"github.com/konflux-ci/namespace-lister/internal/log"
+	"github.com/konflux-ci/namespace-lister/pkg/auth/cache"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func BuildAndRegisterAccessCacheMetrics(registry prometheus.Registerer) (cache.AccessCacheMetrics, error) {
+	if registry == nil {
+		return nil, nil
+	}
+
+	accessCacheMetrics := cache.NewAccessCacheMetrics()
+	if err := registry.Register(accessCacheMetrics); err != nil {
+		return nil, err
+	}
+	return accessCacheMetrics, nil
+}
+
+// GetResyncPeriodFromEnvOrZero retrieves AccessCache's ResyncPeriod from environment variables.
+// If the environment variable is not set it returns the zero value.
+func GetResyncPeriodFromEnvOrZero(ctx context.Context) time.Duration {
+	var zero time.Duration
+	rps, ok := os.LookupEnv(constants.EnvCacheResyncPeriod)
+	if !ok {
+		return zero
+	}
+	rp, err := time.ParseDuration(rps)
+	if err != nil {
+		log.GetLoggerFromContext(ctx).Warn("can not parse duration from environment variable", "error", err)
+		return zero
+	}
+	return rp
+}

--- a/internal/resourcecache/access_cache_test.go
+++ b/internal/resourcecache/access_cache_test.go
@@ -1,0 +1,92 @@
+package resourcecache_test
+
+import (
+	"context"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/konflux-ci/namespace-lister/internal/constants"
+	"github.com/konflux-ci/namespace-lister/internal/resourcecache"
+)
+
+var _ = Describe("Access Cache", func() {
+	Describe("BuildAndRegisterAccessCacheMetrics", func() {
+		var reg *prometheus.Registry
+
+		BeforeEach(func() {
+			reg = prometheus.NewRegistry()
+		})
+
+		It("returns nil metrics when registry is nil", func() {
+			// when
+			metrics, err := resourcecache.BuildAndRegisterAccessCacheMetrics(nil)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metrics).To(BeNil())
+		})
+
+		It("registers and returns metrics with a valid registry", func() {
+			// when
+			metrics, err := resourcecache.BuildAndRegisterAccessCacheMetrics(reg)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metrics).NotTo(BeNil())
+		})
+
+		It("returns an error on duplicate registration", func() {
+			// given
+			_, err := resourcecache.BuildAndRegisterAccessCacheMetrics(reg)
+			Expect(err).NotTo(HaveOccurred())
+
+			// when
+			_, err = resourcecache.BuildAndRegisterAccessCacheMetrics(reg)
+
+			// then
+			Expect(err).To(BeAssignableToTypeOf(prometheus.AlreadyRegisteredError{}))
+		})
+	})
+
+	Describe("GetResyncPeriodFromEnvOrZero", func() {
+		const envKey = constants.EnvCacheResyncPeriod
+
+		It("returns zero when env is not set", func(ctx context.Context) {
+			// given
+			GinkgoT().Setenv(envKey, "dummy")
+			Expect(os.Unsetenv(envKey)).To(Succeed()) //nolint:usetesting // need truly-unset env for this test
+
+			// when
+			d := resourcecache.GetResyncPeriodFromEnvOrZero(ctx)
+
+			// then
+			Expect(d).To(Equal(time.Duration(0)))
+		})
+
+		It("parses a valid duration string", func(ctx context.Context) {
+			// given
+			GinkgoT().Setenv(envKey, "5m")
+
+			// when
+			d := resourcecache.GetResyncPeriodFromEnvOrZero(ctx)
+
+			// then
+			Expect(d).To(Equal(5 * time.Minute))
+		})
+
+		It("returns zero for an invalid duration string", func(ctx context.Context) {
+			// given
+			GinkgoT().Setenv(envKey, "not-a-duration")
+
+			// when
+			d := resourcecache.GetResyncPeriodFromEnvOrZero(ctx)
+
+			// then
+			Expect(d).To(Equal(time.Duration(0)))
+		})
+	})
+})

--- a/internal/resourcecache/internal/transform/transformfuncs_suite_test.go
+++ b/internal/resourcecache/internal/transform/transformfuncs_suite_test.go
@@ -1,0 +1,15 @@
+package transform_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTransformFuncs(t *testing.T) {
+	t.Parallel()
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Transform Suite")
+}

--- a/internal/resourcecache/internal/transform/transformfuncs_test.go
+++ b/internal/resourcecache/internal/transform/transformfuncs_test.go
@@ -1,0 +1,211 @@
+package transform_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/konflux-ci/namespace-lister/internal/resourcecache/internal/transform"
+)
+
+var _ = Describe("Transform Functions", func() {
+	Describe("TrimAnnotations", func() {
+		It("strips annotations from an object", func() {
+			// given
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-ns",
+					Labels:      map[string]string{"team": "infra"},
+					Annotations: map[string]string{"note": "value"},
+				},
+			}
+
+			// when
+			result, err := transform.TrimAnnotations()(ns)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			out := result.(*corev1.Namespace)
+			Expect(out.Annotations).To(BeNil())
+			Expect(out.Labels).To(Equal(map[string]string{"team": "infra"}))
+			Expect(out.Name).To(Equal("test-ns"))
+		})
+
+		It("is a no-op when there are no annotations", func() {
+			// given
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+
+			// when
+			result, err := transform.TrimAnnotations()(ns)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.(*corev1.Namespace).Annotations).To(BeNil())
+		})
+	})
+
+	Describe("MergeTransformFunc", func() {
+		It("chains multiple transforms in order", func() {
+			// given
+			addLabel := func(i interface{}) (interface{}, error) {
+				ns := i.(*corev1.Namespace)
+				if ns.Labels == nil {
+					ns.Labels = map[string]string{}
+				}
+				ns.Labels["added"] = "true"
+				return ns, nil
+			}
+			clearSpec := func(i interface{}) (interface{}, error) {
+				ns := i.(*corev1.Namespace)
+				ns.Spec = corev1.NamespaceSpec{}
+				return ns, nil
+			}
+			merged := transform.MergeTransformFunc(addLabel, clearSpec)
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec:       corev1.NamespaceSpec{Finalizers: []corev1.FinalizerName{corev1.FinalizerKubernetes}},
+			}
+
+			// when
+			result, err := merged(ns)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			out := result.(*corev1.Namespace)
+			Expect(out.Labels).To(HaveKeyWithValue("added", "true"))
+			Expect(out.Spec.Finalizers).To(BeEmpty())
+		})
+
+		It("short-circuits on error", func() {
+			// given
+			failing := func(i interface{}) (interface{}, error) {
+				return nil, errors.New("boom")
+			}
+			shouldNotRun := func(i interface{}) (interface{}, error) {
+				Fail("should not be called")
+				return i, nil
+			}
+			merged := transform.MergeTransformFunc(failing, shouldNotRun)
+
+			// when
+			_, err := merged(&corev1.Namespace{})
+
+			// then
+			Expect(err).To(MatchError("boom"))
+		})
+	})
+
+	Describe("TrimRole", func() {
+		It("keeps a Role with namespace-get rules and strips annotations", func() {
+			// given
+			role := &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "ns-reader",
+					Namespace:   "default",
+					Annotations: map[string]string{"note": "value"},
+				},
+				Rules: []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"namespaces"},
+					Verbs:     []string{"get"},
+				}},
+			}
+
+			// when
+			result, err := transform.TrimRole()(role)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			out := result.(*rbacv1.Role)
+			Expect(out.Rules).To(HaveLen(1))
+			Expect(out.Annotations).To(BeNil())
+		})
+
+		It("returns nil for a Role with no namespace-related rules", func() {
+			// given
+			role := &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-reader"},
+				Rules: []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get"},
+				}},
+			}
+
+			// when
+			result, err := transform.TrimRole()(role)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+
+		It("errors when given a non-Role object", func() {
+			// when
+			_, err := transform.TrimRole()(&corev1.Namespace{})
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected Role"))
+		})
+	})
+
+	Describe("TrimClusterRole", func() {
+		It("keeps a ClusterRole with namespace-get rules and strips annotations", func() {
+			// given
+			cr := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "ns-reader",
+					Annotations: map[string]string{"note": "value"},
+				},
+				Rules: []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"namespaces"},
+					Verbs:     []string{"get"},
+				}},
+			}
+
+			// when
+			result, err := transform.TrimClusterRole()(cr)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			out := result.(*rbacv1.ClusterRole)
+			Expect(out.Rules).To(HaveLen(1))
+			Expect(out.Annotations).To(BeNil())
+		})
+
+		It("returns nil for a ClusterRole with no namespace-related rules", func() {
+			// given
+			cr := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-reader"},
+				Rules: []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get"},
+				}},
+			}
+
+			// when
+			result, err := transform.TrimClusterRole()(cr)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+
+		It("errors when given a non-ClusterRole object", func() {
+			// when
+			_, err := transform.TrimClusterRole()(&corev1.Namespace{})
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a ClusterRole"))
+		})
+	})
+})

--- a/internal/resourcecache/resourcecache_suite_test.go
+++ b/internal/resourcecache/resourcecache_suite_test.go
@@ -1,0 +1,15 @@
+package resourcecache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestResourceCache(t *testing.T) {
+	t.Parallel()
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resource Cache Suite")
+}


### PR DESCRIPTION
## Summary
- Add unit tests for transform functions (`TrimAnnotations`, `MergeTransformFunc`, `TrimRole`, `TrimClusterRole`) in `internal/resourcecache/internal/transform/`
- Move access cache helpers (`BuildAndRegisterAccessCacheMetrics`, `GetResyncPeriodFromEnvOrZero`) from root to `internal/resourcecache/` and add unit tests
- Remove `export_test.go` — all tested functions are now exported in their respective packages

## Test plan
- [x] 10 transform tests pass
- [x] 6 access cache tests pass
- [x] Existing tests unaffected
- [x] No `export_test.go`