### PR TITLE
fix unit tests scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ fmt: ## Run go fmt against code.
 
 .PHONY: test
 test: ## Run go test against code.
-	$(GINKGO) $(GINKGO_ARGS) --label-filter='!perf' ./pkg/... ./
+	$(GINKGO) $(GINKGO_ARGS) --label-filter='!perf' ./pkg/... ./internal/... ./
 
 .PHONY: test-perf
 test-perf: ## Run performance tests


### PR DESCRIPTION
The code in the `internal` folder was not tested. We need to test that one too.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
