### PR TITLE
KFLUXINFRA-3542: add unit tests for access cache helpers

### DIFF
--- a/access_cache_startup.go
+++ b/access_cache_startup.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"context"
-	"os"
-	"time"
 
-	"github.com/konflux-ci/namespace-lister/internal/constants"
 	"github.com/konflux-ci/namespace-lister/internal/log"
+	"github.com/konflux-ci/namespace-lister/internal/resourcecache"
 	"github.com/konflux-ci/namespace-lister/pkg/auth/cache"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -20,7 +18,7 @@ import (
 // buildAndStartSynchronizedAccessCache builds a SynchronizedAccessCache.
 // It registers handlers on events on resources that will trigger an AccessCache synchronization.
 func buildAndStartSynchronizedAccessCache(ctx context.Context, resourceCache crcache.Cache, registry prometheus.Registerer) (*cache.SynchronizedAccessCache, error) {
-	acm, err := buildAndRegisterAccessCacheMetrics(registry)
+	acm, err := resourcecache.BuildAndRegisterAccessCacheMetrics(registry)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +29,7 @@ func buildAndStartSynchronizedAccessCache(ctx context.Context, resourceCache crc
 		sae,
 		resourceCache, cache.CacheSynchronizerOptions{
 			Logger:       log.GetLoggerFromContext(ctx),
-			ResyncPeriod: getResyncPeriodFromEnvOrZero(ctx),
+			ResyncPeriod: resourcecache.GetValidResyncPeriodFromEnvOrZero(ctx),
 			Metrics:      acm,
 		},
 	)
@@ -62,32 +60,3 @@ func buildAndStartSynchronizedAccessCache(ctx context.Context, resourceCache crc
 	return synchCache, nil
 }
 
-func buildAndRegisterAccessCacheMetrics(registry prometheus.Registerer) (cache.AccessCacheMetrics, error) {
-	// if a registry has not been provided, let's proceed without metrics
-	if registry == nil {
-		return nil, nil
-	}
-
-	// build and register the AccessCacheMetrics
-	accessCacheMetrics := cache.NewAccessCacheMetrics()
-	if err := registry.Register(accessCacheMetrics); err != nil {
-		return nil, err
-	}
-	return accessCacheMetrics, nil
-}
-
-// getResyncPeriodFromEnvOrZero retrieves AccessCache's ResyncPeriod from environment variables.
-// If the environment variable is not set it returns the zero value.
-func getResyncPeriodFromEnvOrZero(ctx context.Context) time.Duration {
-	var zero time.Duration
-	rps, ok := os.LookupEnv(constants.EnvCacheResyncPeriod)
-	if !ok {
-		return zero
-	}
-	rp, err := time.ParseDuration(rps)
-	if err != nil {
-		log.GetLoggerFromContext(ctx).Warn("can not parse duration from environment variable", "error", err)
-		return zero
-	}
-	return rp
-}

--- a/internal/resourcecache/access_cache.go
+++ b/internal/resourcecache/access_cache.go
@@ -1,0 +1,44 @@
+package resourcecache
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/konflux-ci/namespace-lister/internal/constants"
+	"github.com/konflux-ci/namespace-lister/internal/log"
+	"github.com/konflux-ci/namespace-lister/pkg/auth/cache"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func BuildAndRegisterAccessCacheMetrics(registry prometheus.Registerer) (cache.AccessCacheMetrics, error) {
+	if registry == nil {
+		return nil, nil
+	}
+
+	accessCacheMetrics := cache.NewAccessCacheMetrics()
+	if err := registry.Register(accessCacheMetrics); err != nil {
+		return nil, err
+	}
+	return accessCacheMetrics, nil
+}
+
+// GetValidResyncPeriodFromEnvOrZero retrieves AccessCache's ResyncPeriod from environment variables.
+// If the environment variable is not set or the value is not a valid positive duration, it returns the zero value.
+func GetValidResyncPeriodFromEnvOrZero(ctx context.Context) time.Duration {
+	var zero time.Duration
+	rps, ok := os.LookupEnv(constants.EnvCacheResyncPeriod)
+	if !ok {
+		return zero
+	}
+	rp, err := time.ParseDuration(rps)
+	if err != nil {
+		log.GetLoggerFromContext(ctx).Warn("can not parse duration from environment variable", "error", err)
+		return zero
+	}
+	if rp < 0 {
+		log.GetLoggerFromContext(ctx).Warn("negative resync period, using zero", "value", rps)
+		return zero
+	}
+	return rp
+}

--- a/internal/resourcecache/access_cache.go
+++ b/internal/resourcecache/access_cache.go
@@ -24,7 +24,7 @@ func BuildAndRegisterAccessCacheMetrics(registry prometheus.Registerer) (cache.A
 }
 
 // GetValidResyncPeriodFromEnvOrZero retrieves AccessCache's ResyncPeriod from environment variables.
-// If the environment variable is not set or the value is not a valid positive duration, it returns the zero value.
+// If the environment variable is not set or the value is not a valid non-negative duration, it returns the zero value.
 func GetValidResyncPeriodFromEnvOrZero(ctx context.Context) time.Duration {
 	var zero time.Duration
 	rps, ok := os.LookupEnv(constants.EnvCacheResyncPeriod)

--- a/internal/resourcecache/access_cache_test.go
+++ b/internal/resourcecache/access_cache_test.go
@@ -1,0 +1,92 @@
+package resourcecache_test
+
+import (
+	"context"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/konflux-ci/namespace-lister/internal/constants"
+	"github.com/konflux-ci/namespace-lister/internal/resourcecache"
+)
+
+var _ = Describe("Access Cache", func() {
+	Describe("BuildAndRegisterAccessCacheMetrics", func() {
+		var reg *prometheus.Registry
+
+		BeforeEach(func() {
+			reg = prometheus.NewRegistry()
+		})
+
+		It("returns nil metrics when registry is nil", func() {
+			// when
+			metrics, err := resourcecache.BuildAndRegisterAccessCacheMetrics(nil)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metrics).To(BeNil())
+		})
+
+		It("registers and returns metrics with a valid registry", func() {
+			// when
+			metrics, err := resourcecache.BuildAndRegisterAccessCacheMetrics(reg)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metrics).NotTo(BeNil())
+
+			families, err := reg.Gather()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(families).NotTo(BeEmpty())
+		})
+
+		It("returns an error on duplicate registration", func() {
+			// given
+			_, err := resourcecache.BuildAndRegisterAccessCacheMetrics(reg)
+			Expect(err).NotTo(HaveOccurred())
+
+			// when
+			_, err = resourcecache.BuildAndRegisterAccessCacheMetrics(reg)
+
+			// then
+			Expect(err).To(BeAssignableToTypeOf(prometheus.AlreadyRegisteredError{}))
+		})
+	})
+
+	Describe("GetValidResyncPeriodFromEnvOrZero", Serial, func() {
+		It("returns zero when env is not set", func(ctx context.Context) {
+			// given
+			if v, ok := os.LookupEnv(constants.EnvCacheResyncPeriod); ok {
+				Expect(os.Unsetenv(constants.EnvCacheResyncPeriod)).To(Succeed()) //nolint:usetesting
+				defer os.Setenv(constants.EnvCacheResyncPeriod, v)                //nolint:usetesting
+			}
+
+			// when
+			d := resourcecache.GetValidResyncPeriodFromEnvOrZero(ctx)
+
+			// then
+			Expect(d).To(Equal(time.Duration(0)))
+		})
+
+		DescribeTable("parses env value",
+			func(ctx context.Context, envValue string, expected time.Duration) {
+				// given
+				GinkgoT().Setenv(constants.EnvCacheResyncPeriod, envValue)
+
+				// when
+				d := resourcecache.GetValidResyncPeriodFromEnvOrZero(ctx)
+
+				// then
+				Expect(d).To(Equal(expected))
+			},
+			Entry("valid duration 5m", "5m", 5*time.Minute),
+			Entry("valid duration 30s", "30s", 30*time.Second),
+			Entry("valid duration 1h", "1h", time.Hour),
+			Entry("invalid duration returns zero", "not-a-duration", time.Duration(0)),
+			Entry("negative duration returns zero", "-1h", time.Duration(0)),
+		)
+	})
+})

--- a/internal/resourcecache/resourcecache_suite_test.go
+++ b/internal/resourcecache/resourcecache_suite_test.go
@@ -1,0 +1,15 @@
+package resourcecache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestResourceCache(t *testing.T) {
+	t.Parallel()
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resource Cache Suite")
+}


### PR DESCRIPTION
## Summary
- Move BuildAndRegisterAccessCacheMetrics and GetResyncPeriodFromEnvOrZero from root to internal/resourcecache/ and export them
- Add unit tests with DescribeTable for duration parsing (multiple valid formats + invalid input)
- Verify metrics are actually registered in the registry
- Remove export_test.go

## Test plan
- [x] 8 tests pass locally
- [x] Root package compiles cleanly with updated imports