### PR TITLE
enable e2e coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p coverage-output && chmod 777 coverage-output
-          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 400 /tmp/kubeconfig
+          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 600 /tmp/kubeconfig
           podman run --rm \
             --network host \
             -v /tmp/kubeconfig:/kubeconfig:ro \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
         if: always()
         run: |
           mkdir -p coverage-output && chmod 777 coverage-output
-          cp $HOME/.kube/config /tmp/kubeconfig && chmod 644 /tmp/kubeconfig
+          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 644 /tmp/kubeconfig
           podman run --rm \
             --network host \
             -v /tmp/kubeconfig:/kubeconfig:ro \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,11 +134,6 @@ jobs:
               --test-name=e2e-tests \
               --output=/workspace/coverage-output
 
-      - name: Warn on Collect e2e coverage failure
-        if: steps.collect_e2e_coverage.outcome == 'failure'
-        run: |
-          echo "::warning title=Coverage Collection Failed::The Collect E2E Coverage failed."
-
       - name: Upload e2e coverage to Codecov
         if: steps.collect_e2e_coverage.outcome == 'success'
         id: upload_e2e_coverage
@@ -148,11 +143,6 @@ jobs:
           flags: e2e-tests
           directory: coverage-output
           fail_ci_if_error: false
-
-      - name: Warn on Upload e2e coverage failure
-        if: steps.upload_e2e_coverage.outcome == 'failure'
-        run: |
-          echo "::warning title=Coverage Upload Failed::The Upload E2E Coverage failed."
 
 
   go-tidy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,8 @@ jobs:
   acceptance:
     name: Run acceptance tests
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -101,8 +103,10 @@ jobs:
 
       - name: Run tests
         env:
-          IMAGE_BUILDER: docker
-          IMG: namespace-lister:pr-${{ github.event.pull_request.number }}
+          KIND_EXPERIMENTAL_PROVIDER: podman
+          IMAGE_BUILDER: podman
+          IMG: konflux-ci.dev/namespace-lister:pr-${{ github.event.pull_request.number }}
+          ENABLE_COVERAGE: "true"
         run: |
           echo "##[group] Preparing environment"
             make -C "acceptance/test/${{ matrix.proxy }}" prepare
@@ -110,6 +114,32 @@ jobs:
           echo "##[group] Running tests"
             make -C "acceptance/test/${{ matrix.proxy }}" test
           echo "##[endgroup]"
+
+      - name: Collect e2e coverage
+        if: always()
+        run: |
+          mkdir -p coverage-output && chmod 777 coverage-output
+          cp $HOME/.kube/config /tmp/kubeconfig && chmod 644 /tmp/kubeconfig
+          podman run --rm \
+            --network host \
+            -v /tmp/kubeconfig:/kubeconfig:ro \
+            -v $PWD/coverage-output:/workspace/coverage-output \
+            -e KUBECONFIG=/kubeconfig \
+            quay.io/konflux-ci/konflux-devprod/coverport-cli \
+            collect \
+              --namespace=namespace-lister \
+              --label-selector=apps=namespace-lister \
+              --test-name=e2e-tests \
+              --output=/workspace/coverage-output || true
+
+      - name: Upload e2e coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: e2e-tests
+          directory: coverage-output
+          fail_ci_if_error: false
 
   go-tidy:
     name: Tidy go mod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p coverage-output && chmod 777 coverage-output
-          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 644 /tmp/kubeconfig
+          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 400 /tmp/kubeconfig
           podman run --rm \
             --network host \
             -v /tmp/kubeconfig:/kubeconfig:ro \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,7 @@ jobs:
             -v /tmp/kubeconfig:/kubeconfig:ro \
             -v $PWD/coverage-output:/workspace/coverage-output \
             -e KUBECONFIG=/kubeconfig \
-            quay.io/konflux-ci/konflux-devprod/coverport-cli@sha256:9a2d0a42fcc0dcea31c1b20b2752bb4dfe76f92a99314968e24f525c782a03f1 \
+            quay.io/konflux-ci/konflux-devprod/coverport-cli \
             collect \
               --namespace=namespace-lister \
               --label-selector=apps=namespace-lister \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p coverage-output && chmod 777 coverage-output
-          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 600 /tmp/kubeconfig
+          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 644 /tmp/kubeconfig
           podman run --rm \
             --network host \
             -v /tmp/kubeconfig:/kubeconfig:ro \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,9 @@ jobs:
           echo "##[endgroup]"
 
       - name: Collect e2e coverage
+        id: collect_e2e_coverage
         if: always()
+        continue-on-error: true
         run: |
           mkdir -p coverage-output && chmod 777 coverage-output
           cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 400 /tmp/kubeconfig
@@ -130,16 +132,28 @@ jobs:
               --namespace=namespace-lister \
               --label-selector=apps=namespace-lister \
               --test-name=e2e-tests \
-              --output=/workspace/coverage-output || true
+              --output=/workspace/coverage-output
+
+      - name: Warn on Collect e2e coverage failure
+        if: steps.collect_e2e_coverage.outcome == 'failure'
+        run: |
+          echo "::warning title=Coverage Collection Failed::The Collect E2E Coverage failed."
 
       - name: Upload e2e coverage to Codecov
-        if: always()
+        if: steps.collect_e2e_coverage.outcome == 'success'
+        id: upload_e2e_coverage
         uses: codecov/codecov-action@v6
         with:
           use_oidc: true
           flags: e2e-tests
           directory: coverage-output
           fail_ci_if_error: false
+
+      - name: Warn on Upload e2e coverage failure
+        if: steps.upload_e2e_coverage.outcome == 'failure'
+        run: |
+          echo "::warning title=Coverage Upload Failed::The Upload E2E Coverage failed."
+
 
   go-tidy:
     name: Tidy go mod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
             -v /tmp/kubeconfig:/kubeconfig:ro \
             -v $PWD/coverage-output:/workspace/coverage-output \
             -e KUBECONFIG=/kubeconfig \
-            quay.io/konflux-ci/konflux-devprod/coverport-cli \
+            quay.io/konflux-ci/konflux-devprod/coverport-cli@sha256:9a2d0a42fcc0dcea31c1b20b2752bb4dfe76f92a99314968e24f525c782a03f1 \
             collect \
               --namespace=namespace-lister \
               --label-selector=apps=namespace-lister \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload e2e coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           use_oidc: true
           flags: e2e-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,13 +121,13 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p coverage-output && chmod 777 coverage-output
-          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 400 /tmp/kubeconfig
+          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 644 /tmp/kubeconfig
           podman run --rm \
             --network host \
             -v /tmp/kubeconfig:/kubeconfig:ro \
             -v $PWD/coverage-output:/workspace/coverage-output \
             -e KUBECONFIG=/kubeconfig \
-            quay.io/konflux-ci/konflux-devprod/coverport-cli \
+            quay.io/konflux-ci/konflux-devprod/coverport-cli@sha256:44c180e1e3a3521b1057f4e85723efef2eb2107a153c9c5e91dfdb0f5631e41d \
             collect \
               --namespace=namespace-lister \
               --label-selector=apps=namespace-lister \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
         if: always()
         run: |
           mkdir -p coverage-output && chmod 777 coverage-output
-          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 644 /tmp/kubeconfig
+          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 400 /tmp/kubeconfig
           podman run --rm \
             --network host \
             -v /tmp/kubeconfig:/kubeconfig:ro \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p coverage-output && chmod 777 coverage-output
-          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 644 /tmp/kubeconfig
+          cp "acceptance/test/${{ matrix.proxy }}/out/namespace-lister-admin.kcfg" /tmp/kubeconfig && chmod 600 /tmp/kubeconfig
           podman run --rm \
             --network host \
             -v /tmp/kubeconfig:/kubeconfig:ro \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778171507@sha256:f9c8537
 ARG TARGETOS
 ARG TARGETARCH
 
+ARG ENABLE_COVERAGE=false
+
 WORKDIR /namespace-lister
 
 # Copy the Go Modules manifests
@@ -19,7 +21,14 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -trimpath -a -o /tmp/server .
+# Build with or without coverage instrumentation
+RUN if [ "$ENABLE_COVERAGE" = "true" ]; then \
+        echo "Building with coverage instrumentation..."; \
+        CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -cover -covermode=atomic -tags=coverage -o /tmp/server ./ ; \
+    else \
+        echo "Building production binary..."; \
+        CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -trimpath -a -o /tmp/server . ; \
+    fi
 
 FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:1ef916d40ff7f1a4882a31ad5ab37f9572baa7bd182c3519d5e0cb557ffc04f3
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ GOLANGCI_LINT ?= go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$
 IMG ?= namespace-lister:latest
 IMAGE_BUILDER ?= docker
 
+ENABLE_COVERAGE ?= false
+
 ## Local Folders
 $(LOCALBIN):
 	mkdir $(LOCALBIN)
@@ -70,7 +72,7 @@ test-perf: ## Run performance tests
 
 .PHONY: image-build
 image-build:
-	$(IMAGE_BUILDER) build -t "$(IMG)" .
+	$(IMAGE_BUILDER) build --build-arg ENABLE_COVERAGE=$(ENABLE_COVERAGE) -t "$(IMG)" .
 
 .PHONY: generate-code
 generate-code: mockgen  ## Run go generate on the project.

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,8 @@ coverage:
 flags:
   unit-tests:
     carryforward: true
+  e2e-tests:
+    carryforward: true
 
 comment:
   layout: "reach,diff,flags,files"

--- a/coverage_init.go
+++ b/coverage_init.go
@@ -1,0 +1,9 @@
+//go:build coverage
+
+package main
+
+// This file is only included when building with -tags=coverage.
+// It starts a coverage HTTP server that allows collecting coverage data
+// from the running binary during E2E tests.
+
+import _ "github.com/konflux-ci/coverport/instrumentation/go" // starts coverage server via init()

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-logr/logr v1.4.3
+	github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20260511122848-7619cbd17392
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20260511122848-7619cbd17392 h1:pAAHdo/2UaGFtpgwNJmg1Kp3nLpDL0wzCOUTya9wBhE=
+github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20260511122848-7619cbd17392/go.mod h1:WVMHU9A2464s/vjH1xOTm4LJDD4xP+VlEiU+KM0gkSU=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
this enables reporting of e2e tests coverage to codecov

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
