### PR TITLE
feat: add health and metrics acceptance test suites

### DIFF
--- a/acceptance/pkg/context/context.go
+++ b/acceptance/pkg/context/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"crypto/tls"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -10,10 +11,12 @@ import (
 type ContextKey string
 
 const (
-	ContextKeyNamespaces      ContextKey = "namespaces"
-	ContextKeyRunId           ContextKey = "run-id"
-	ContextKeyUserInfo        ContextKey = "user-info"
-	ContextKeyBuildUserClient ContextKey = "build-user-client"
+	ContextKeyNamespaces             ContextKey = "namespaces"
+	ContextKeyRunId                  ContextKey = "run-id"
+	ContextKeyUserInfo               ContextKey = "user-info"
+	ContextKeyBuildUserClient        ContextKey = "build-user-client"
+	ContextKeyNamespaceListerAddress ContextKey = "namespace-lister-address"
+	ContextKeyTLSConfig ContextKey = "tls-config"
 )
 
 type BuildUserClientFunc func(context.Context) (client.Client, error)
@@ -48,6 +51,22 @@ func WithRunId(ctx context.Context, runId string) context.Context {
 
 func RunId(ctx context.Context) string {
 	return get[string](ctx, ContextKeyRunId)
+}
+
+func WithNamespaceListerAddress(ctx context.Context, address string) context.Context {
+	return into(ctx, ContextKeyNamespaceListerAddress, address)
+}
+
+func NamespaceListerAddress(ctx context.Context) string {
+	return get[string](ctx, ContextKeyNamespaceListerAddress)
+}
+
+func WithTLSConfig(ctx context.Context, cfg *tls.Config) context.Context {
+	return into(ctx, ContextKeyTLSConfig, cfg)
+}
+
+func TLSConfig(ctx context.Context) *tls.Config {
+	return get[*tls.Config](ctx, ContextKeyTLSConfig)
 }
 
 // aux

--- a/acceptance/pkg/suite/env.go
+++ b/acceptance/pkg/suite/env.go
@@ -2,11 +2,33 @@ package suite
 
 import (
 	"cmp"
+	"context"
+	"crypto/tls"
 	"os"
+
+	"github.com/cucumber/godog"
+
+	tcontext "github.com/konflux-ci/namespace-lister/acceptance/pkg/context"
 )
 
 const EnvKonfluxAddress string = "KONFLUX_ADDRESS"
 
 func EnvKonfluxAddressOrDefault(address string) string {
 	return cmp.Or(os.Getenv(EnvKonfluxAddress), address)
+}
+
+func BuildTLSConfig() *tls.Config {
+	if os.Getenv("E2E_USE_INSECURE_TLS") == "true" {
+		return &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	return &tls.Config{}
+}
+
+func InjectServiceAddresses(defaultAddress string) func(context.Context, *godog.Scenario) (context.Context, error) {
+	return func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
+		address := EnvKonfluxAddressOrDefault(defaultAddress)
+		ctx = tcontext.WithNamespaceListerAddress(ctx, address)
+		ctx = tcontext.WithTLSConfig(ctx, BuildTLSConfig())
+		return ctx, nil
+	}
 }

--- a/acceptance/pkg/suite/steps_health.go
+++ b/acceptance/pkg/suite/steps_health.go
@@ -1,0 +1,61 @@
+package suite
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	tcontext "github.com/konflux-ci/namespace-lister/acceptance/pkg/context"
+)
+
+func InjectHealthSteps(ctx *godog.ScenarioContext) {
+	ctx.Then(`^the healthz endpoint returns 200$`, healthzReturns200)
+	ctx.Then(`^the readyz endpoint returns 200$`, readyzReturns200)
+}
+
+func healthzReturns200(ctx context.Context) (context.Context, error) {
+	return checkEndpoint(ctx, "/healthz")
+}
+
+func readyzReturns200(ctx context.Context) (context.Context, error) {
+	return checkEndpoint(ctx, "/readyz")
+}
+
+func checkEndpoint(ctx context.Context, path string) (context.Context, error) {
+	address := tcontext.NamespaceListerAddress(ctx)
+	if address == "" {
+		return ctx, fmt.Errorf("namespace-lister address not set in context")
+	}
+
+	tlsConfig := tcontext.TLSConfig(ctx)
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, address+path, nil)
+	if err != nil {
+		return ctx, fmt.Errorf("error building request for %s: %w", path, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return ctx, fmt.Errorf("error requesting %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		return ctx, fmt.Errorf("error reading response body from %s: %w", path, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return ctx, fmt.Errorf("expected 200 from %s, got %d", path, resp.StatusCode)
+	}
+
+	return ctx, nil
+}

--- a/acceptance/pkg/suite/steps_metrics.go
+++ b/acceptance/pkg/suite/steps_metrics.go
@@ -1,0 +1,45 @@
+package suite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cucumber/godog"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	arest "github.com/konflux-ci/namespace-lister/acceptance/pkg/rest"
+)
+
+func InjectMetricsSteps(ctx *godog.ScenarioContext) {
+	ctx.Then(`^the metrics service is available in the cluster$`, metricsServiceIsAvailable)
+}
+
+func metricsServiceIsAvailable(ctx context.Context) (context.Context, error) {
+	cli, err := arest.BuildDefaultHostClient()
+	if err != nil {
+		return ctx, err
+	}
+
+	svc := &corev1.Service{}
+	if err := cli.Get(ctx, types.NamespacedName{
+		Name:      "namespace-lister-metrics",
+		Namespace: "namespace-lister",
+	}, svc); err != nil {
+		return ctx, fmt.Errorf("metrics service not found: %w", err)
+	}
+
+	found := false
+	for _, p := range svc.Spec.Ports {
+		if p.Port == 9100 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ctx, fmt.Errorf("metrics service does not expose port 9100")
+	}
+
+	return ctx, nil
+}

--- a/acceptance/test/dumb-proxy/config/proxy/nginx.conf
+++ b/acceptance/test/dumb-proxy/config/proxy/nginx.conf
@@ -57,6 +57,16 @@ http {
             proxy_read_timeout 1m;
         }
 
+        location = /healthz {
+            proxy_pass https://namespace-lister.namespace-lister.svc.cluster.local:12000;
+            proxy_read_timeout 1m;
+        }
+
+        location = /readyz {
+            proxy_pass https://namespace-lister.namespace-lister.svc.cluster.local:12000;
+            proxy_read_timeout 1m;
+        }
+
         location / {
             # Kube-API
             proxy_pass https://kubernetes.default.svc/;

--- a/acceptance/test/dumb-proxy/features/health.feature
+++ b/acceptance/test/dumb-proxy/features/health.feature
@@ -1,0 +1,8 @@
+@health
+Feature: Health Endpoints
+
+  Scenario: Liveness endpoint returns 200
+    Then the healthz endpoint returns 200
+
+  Scenario: Readiness endpoint returns 200
+    Then the readyz endpoint returns 200

--- a/acceptance/test/dumb-proxy/features/metrics.feature
+++ b/acceptance/test/dumb-proxy/features/metrics.feature
@@ -1,0 +1,5 @@
+@metrics
+Feature: Prometheus Metrics
+
+  Scenario: Metrics service exists
+    Then the metrics service is available in the cluster

--- a/acceptance/test/dumb-proxy/hook_test.go
+++ b/acceptance/test/dumb-proxy/hook_test.go
@@ -17,6 +17,7 @@ func InjectHooks(ctx *godog.ScenarioContext) {
 	suite.InjectBaseHooks(ctx)
 
 	ctx.Before(injectBuildUserClient)
+	ctx.Before(suite.InjectServiceAddresses(defaultTestAddress))
 }
 
 func injectBuildUserClient(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
@@ -24,7 +25,6 @@ func injectBuildUserClient(ctx context.Context, sc *godog.Scenario) (context.Con
 }
 
 func buildUserClientWithTokenReview(ctx context.Context) (client.Client, error) {
-	// build client with bearer token
 	cfg, err := arest.NewDefaultClientConfig()
 	if err != nil {
 		return nil, err

--- a/acceptance/test/dumb-proxy/step_test.go
+++ b/acceptance/test/dumb-proxy/step_test.go
@@ -8,4 +8,6 @@ import (
 
 func InjectSteps(ctx *godog.ScenarioContext) {
 	suite.InjectSteps(ctx)
+	suite.InjectHealthSteps(ctx)
+	suite.InjectMetricsSteps(ctx)
 }

--- a/acceptance/test/smart-proxy/config/proxy-auth/nginx.conf
+++ b/acceptance/test/smart-proxy/config/proxy-auth/nginx.conf
@@ -57,6 +57,16 @@ http {
             proxy_read_timeout 1m;
         }
 
+        location = /healthz {
+            proxy_pass https://namespace-lister.namespace-lister.svc.cluster.local:12000;
+            proxy_read_timeout 1m;
+        }
+
+        location = /readyz {
+            proxy_pass https://namespace-lister.namespace-lister.svc.cluster.local:12000;
+            proxy_read_timeout 1m;
+        }
+
         location / {
             # Kube-API
             proxy_pass https://kubernetes.default.svc/;

--- a/acceptance/test/smart-proxy/features/health.feature
+++ b/acceptance/test/smart-proxy/features/health.feature
@@ -1,0 +1,8 @@
+@health
+Feature: Health Endpoints
+
+  Scenario: Liveness endpoint returns 200
+    Then the healthz endpoint returns 200
+
+  Scenario: Readiness endpoint returns 200
+    Then the readyz endpoint returns 200

--- a/acceptance/test/smart-proxy/features/metrics.feature
+++ b/acceptance/test/smart-proxy/features/metrics.feature
@@ -1,0 +1,5 @@
+@metrics
+Feature: Prometheus Metrics
+
+  Scenario: Metrics service exists
+    Then the metrics service is available in the cluster

--- a/acceptance/test/smart-proxy/hook_test.go
+++ b/acceptance/test/smart-proxy/hook_test.go
@@ -17,6 +17,7 @@ func InjectHooks(ctx *godog.ScenarioContext) {
 	suite.InjectBaseHooks(ctx)
 
 	ctx.Before(injectBuildUserClient)
+	ctx.Before(suite.InjectServiceAddresses(defaultTestAddress))
 }
 
 func injectBuildUserClient(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
@@ -24,7 +25,6 @@ func injectBuildUserClient(ctx context.Context, sc *godog.Scenario) (context.Con
 }
 
 func buildUserClientForAuthProxy(ctx context.Context) (client.Client, error) {
-	// build impersonating client
 	cfg, err := arest.NewDefaultClientConfig()
 	if err != nil {
 		return nil, err
@@ -39,14 +39,10 @@ func buildUserClientForAuthProxy(ctx context.Context) (client.Client, error) {
 }
 
 func buildUnauthenticatedUserClientForAuthProxy(ctx context.Context) (client.Client, error) {
-	// build impersonating client
 	cfg, err := arest.NewDefaultClientConfig()
 	if err != nil {
 		return nil, err
 	}
-
-	// the client should be unauthenticated,
-	// so skip any impersonation here
 
 	cfg.Host = suite.EnvKonfluxAddressOrDefault(defaultTestAddress)
 	return arest.BuildClient(cfg)

--- a/acceptance/test/smart-proxy/step_test.go
+++ b/acceptance/test/smart-proxy/step_test.go
@@ -13,6 +13,8 @@ import (
 
 func InjectSteps(ctx *godog.ScenarioContext) {
 	suite.InjectSteps(ctx)
+	suite.InjectHealthSteps(ctx)
+	suite.InjectMetricsSteps(ctx)
 
 	ctx.Given("^User is not authenticated$", userIsNotAuthenticated)
 }


### PR DESCRIPTION
Add BDD tests for service health and observability:
- Liveness endpoint returns 200
- Readiness endpoint returns 200
- Metrics service is available in the cluster

Contributes to: KFLUXINFRA-3243