### PR TITLE
feat: add errors acceptance test suite

### DIFF
--- a/acceptance/pkg/suite/steps.go
+++ b/acceptance/pkg/suite/steps.go
@@ -257,6 +257,7 @@ func TheUserRetrievesNoNamespaces(ctx context.Context) (context.Context, error) 
 }
 
 func TheUserCanRetrieveOnlyTheNamespacesTheyHaveAccessTo(ctx context.Context) (context.Context, error) {
+	run := tcontext.RunId(ctx)
 	cli, err := tcontext.InvokeBuildUserClientFunc(ctx)
 	if err != nil {
 		return ctx, err
@@ -269,21 +270,31 @@ func TheUserCanRetrieveOnlyTheNamespacesTheyHaveAccessTo(ctx context.Context) (c
 			return false, nil
 		}
 
-		enn := tcontext.Namespaces(ctx)
-		if expected, actual := len(enn), len(ann.Items); expected != actual {
-			ad := make([]string, len(ann.Items))
-			for _, n := range ann.Items {
-				ad = append(ad, n.Name)
+		// filter to the current test run to avoid counting leftover
+		// namespaces from previous scenarios (e.g. the system:authenticated
+		// group scenario grants access to all authenticated SAs)
+		var runItems []corev1.Namespace
+		for _, n := range ann.Items {
+			if n.Labels["namespace-lister/test-run"] == run {
+				runItems = append(runItems, n)
 			}
-			log.Printf("expected %d namespaces, actual %d: %v", expected, actual, ad)
+		}
+
+		enn := tcontext.Namespaces(ctx)
+		if expected, actual := len(enn), len(runItems); expected != actual {
+			names := make([]string, len(runItems))
+			for i, n := range runItems {
+				names[i] = n.Name
+			}
+			log.Printf("expected %d namespaces for run %s, actual %d: %v", expected, run, actual, names)
 			return false, nil
 		}
 
 		for _, en := range enn {
-			if !slices.ContainsFunc(ann.Items, func(an corev1.Namespace) bool {
+			if !slices.ContainsFunc(runItems, func(an corev1.Namespace) bool {
 				return en.Name == an.Name
 			}) {
-				log.Printf("expected namespace %s not found in actual namespace list: %v", en.Name, ann.Items)
+				log.Printf("expected namespace %s not found in actual namespace list", en.Name)
 				return false, nil
 			}
 		}

--- a/acceptance/pkg/suite/steps.go
+++ b/acceptance/pkg/suite/steps.go
@@ -36,10 +36,11 @@ func InjectSteps(ctx *godog.ScenarioContext) {
 	ctx.Then(`^the User can retrieve only the namespaces they have access to$`, TheUserCanRetrieveOnlyTheNamespacesTheyHaveAccessTo)
 	ctx.Then(`^the ServiceAccount retrieves namespaces$`, TheUserRetrievesNamespaces)
 	ctx.Then(`^the ServiceAccount retrieves no namespaces$`, TheUserRetrievesNoNamespaces)
-	ctx.Then(`^the User request is rejected with unauthorized error$`, userRequestIsRejectedWithUnauthorizerError)
+	ctx.Then(`^the User request is rejected with unauthorized error$`, theUserRequestReturnsUnauthorized)
+	ctx.Then(`^the user request returns unauthorized$`, theUserRequestReturnsUnauthorized)
 }
 
-func userRequestIsRejectedWithUnauthorizerError(ctx context.Context) (context.Context, error) {
+func theUserRequestReturnsUnauthorized(ctx context.Context) (context.Context, error) {
 	cli, err := tcontext.InvokeBuildUserClientFunc(ctx)
 	if err != nil {
 		return ctx, err

--- a/acceptance/pkg/suite/steps.go
+++ b/acceptance/pkg/suite/steps.go
@@ -46,11 +46,14 @@ func userRequestIsRejectedWithUnauthorizerError(ctx context.Context) (context.Co
 	}
 
 	nn := corev1.NamespaceList{}
-	if err := cli.List(ctx, &nn); !errors.IsUnauthorized(err) {
-		return ctx, err
+	if err := cli.List(ctx, &nn); err != nil {
+		if errors.IsUnauthorized(err) {
+			return ctx, nil
+		}
+		return ctx, fmt.Errorf("expected unauthorized error, got: %v", err)
 	}
 
-	return ctx, nil
+	return ctx, fmt.Errorf("expected unauthorized error, but request succeeded with %d items", len(nn.Items))
 }
 
 func NTenantNamespacesExist(ctx context.Context, limit int) (context.Context, error) {

--- a/acceptance/pkg/suite/steps_errors.go
+++ b/acceptance/pkg/suite/steps_errors.go
@@ -1,0 +1,34 @@
+package suite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cucumber/godog"
+
+	corev1 "k8s.io/api/core/v1"
+
+	tcontext "github.com/konflux-ci/namespace-lister/acceptance/pkg/context"
+)
+
+func InjectErrorSteps(ctx *godog.ScenarioContext) {
+	ctx.Then(`^the user gets an empty namespace list$`, theUserGetsAnEmptyNamespaceList)
+}
+
+func theUserGetsAnEmptyNamespaceList(ctx context.Context) (context.Context, error) {
+	cli, err := tcontext.InvokeBuildUserClientFunc(ctx)
+	if err != nil {
+		return ctx, err
+	}
+
+	nn := corev1.NamespaceList{}
+	if err := cli.List(ctx, &nn); err != nil {
+		return ctx, fmt.Errorf("expected successful response, got error: %v", err)
+	}
+
+	if len(nn.Items) != 0 {
+		return ctx, fmt.Errorf("expected empty namespace list, got %d items", len(nn.Items))
+	}
+
+	return ctx, nil
+}

--- a/acceptance/pkg/suite/steps_response.go
+++ b/acceptance/pkg/suite/steps_response.go
@@ -1,0 +1,40 @@
+package suite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cucumber/godog"
+
+	corev1 "k8s.io/api/core/v1"
+
+	tcontext "github.com/konflux-ci/namespace-lister/acceptance/pkg/context"
+)
+
+func InjectResponseSteps(ctx *godog.ScenarioContext) {
+	ctx.Then(`^the response is a valid NamespaceList$`, theResponseIsAValidNamespaceList)
+}
+
+func theResponseIsAValidNamespaceList(ctx context.Context) (context.Context, error) {
+	cli, err := tcontext.InvokeBuildUserClientFunc(ctx)
+	if err != nil {
+		return ctx, fmt.Errorf("error building user client: %w", err)
+	}
+
+	// cli.List deserializes the response into a typed corev1.NamespaceList;
+	// if this succeeds the server returned a valid NamespaceList payload.
+	// Kind/APIVersion are stripped by controller-runtime during decoding
+	// so we cannot assert them here.
+	nn := corev1.NamespaceList{}
+	if err := cli.List(ctx, &nn); err != nil {
+		return ctx, fmt.Errorf("error listing namespaces: %w", err)
+	}
+
+	for i, item := range nn.Items {
+		if item.Name == "" {
+			return ctx, fmt.Errorf("item[%d] has empty metadata.name", i)
+		}
+	}
+
+	return ctx, nil
+}

--- a/acceptance/test/dumb-proxy/features/errors.feature
+++ b/acceptance/test/dumb-proxy/features/errors.feature
@@ -1,0 +1,9 @@
+@errors
+Feature: Error Handling
+
+  Scenario: Invalid token returns 401
+    Given User is not authenticated
+    Then the user request returns unauthorized
+
+  Scenario: Authenticated user with no bindings gets empty list
+    Then the user gets an empty namespace list

--- a/acceptance/test/dumb-proxy/features/response.feature
+++ b/acceptance/test/dumb-proxy/features/response.feature
@@ -1,0 +1,7 @@
+@response
+Feature: Response Format
+
+  Scenario: Response is a valid NamespaceList
+    Given ServiceAccount has access to "3" namespaces
+    Then the ServiceAccount can retrieve only the namespaces they have access to
+    Then the response is a valid NamespaceList

--- a/acceptance/test/dumb-proxy/step_test.go
+++ b/acceptance/test/dumb-proxy/step_test.go
@@ -1,13 +1,41 @@
 package acceptance
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/cucumber/godog"
 
+	tcontext "github.com/konflux-ci/namespace-lister/acceptance/pkg/context"
+	arest "github.com/konflux-ci/namespace-lister/acceptance/pkg/rest"
 	"github.com/konflux-ci/namespace-lister/acceptance/pkg/suite"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func InjectSteps(ctx *godog.ScenarioContext) {
 	suite.InjectSteps(ctx)
 	suite.InjectHealthSteps(ctx)
 	suite.InjectMetricsSteps(ctx)
+	suite.InjectErrorSteps(ctx)
+	suite.InjectResponseSteps(ctx)
+
+	ctx.Given("^User is not authenticated$", dumbProxyUserIsNotAuthenticated)
+}
+
+func dumbProxyUserIsNotAuthenticated(ctx context.Context) (context.Context, error) {
+	runId := tcontext.RunId(ctx)
+	username := fmt.Sprintf("user-%s", runId)
+	user := tcontext.UserInfoFromUsername(username)
+	ctx = tcontext.WithUser(ctx, user)
+
+	ctx = tcontext.WithBuildUserClientFunc(ctx, func(ctx context.Context) (client.Client, error) {
+		cfg, err := arest.NewDefaultClientConfig()
+		if err != nil {
+			return nil, err
+		}
+		cfg.BearerToken = "invalid-token"
+		cfg.Host = suite.EnvKonfluxAddressOrDefault(defaultTestAddress)
+		return arest.BuildClient(cfg)
+	})
+	return ctx, nil
 }

--- a/acceptance/test/smart-proxy/features/errors.feature
+++ b/acceptance/test/smart-proxy/features/errors.feature
@@ -1,0 +1,6 @@
+@errors
+Feature: Error Handling
+
+  Scenario: Authenticated user with no bindings gets empty list
+    Given User has access to "0" namespaces
+    Then the user gets an empty namespace list

--- a/acceptance/test/smart-proxy/features/response.feature
+++ b/acceptance/test/smart-proxy/features/response.feature
@@ -1,0 +1,7 @@
+@response
+Feature: Response Format
+
+  Scenario: Response is a valid NamespaceList
+    Given User has access to "3" namespaces
+    Then the User can retrieve only the namespaces they have access to
+    Then the response is a valid NamespaceList

--- a/acceptance/test/smart-proxy/hook_test.go
+++ b/acceptance/test/smart-proxy/hook_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/cucumber/godog"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	tcontext "github.com/konflux-ci/namespace-lister/acceptance/pkg/context"
@@ -44,6 +45,14 @@ func buildUnauthenticatedUserClientForAuthProxy(ctx context.Context) (client.Cli
 		return nil, err
 	}
 
-	cfg.Host = suite.EnvKonfluxAddressOrDefault(defaultTestAddress)
-	return arest.BuildClient(cfg)
+	// build a new config with only connectivity settings (no credentials)
+	unauthCfg := &rest.Config{
+		Host: suite.EnvKonfluxAddressOrDefault(defaultTestAddress),
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: cfg.Insecure,
+			CAFile:   cfg.CAFile,
+			CAData:   cfg.CAData,
+		},
+	}
+	return arest.BuildClient(unauthCfg)
 }

--- a/acceptance/test/smart-proxy/step_test.go
+++ b/acceptance/test/smart-proxy/step_test.go
@@ -15,6 +15,8 @@ func InjectSteps(ctx *godog.ScenarioContext) {
 	suite.InjectSteps(ctx)
 	suite.InjectHealthSteps(ctx)
 	suite.InjectMetricsSteps(ctx)
+	suite.InjectErrorSteps(ctx)
+	suite.InjectResponseSteps(ctx)
 
 	ctx.Given("^User is not authenticated$", userIsNotAuthenticated)
 }


### PR DESCRIPTION
Add BDD tests for error handling behavior:
- Invalid token returns 401
- Authenticated user with no bindings gets empty list
- Response format is a valid NamespaceList

Contributes to: KFLUXINFRA-3243