### PR TITLE
Add AGENTS.md and CI lint workflow

### DIFF
--- a/.github/workflows/agents-md-lint.yaml
+++ b/.github/workflows/agents-md-lint.yaml
@@ -1,0 +1,33 @@
+name: Lint AGENTS.md
+
+on:
+  pull_request:
+    paths:
+      - AGENTS.md
+  push:
+    branches: [main]
+    paths:
+      - AGENTS.md
+
+permissions:
+  contents: read
+
+jobs:
+  agents-md-lint:
+    name: Check AGENTS.md line limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate AGENTS.md
+        run: |
+          if [ ! -f AGENTS.md ]; then
+            echo "ERROR: AGENTS.md not found"
+            exit 1
+          fi
+          lines=$(wc -l < AGENTS.md)
+          echo "AGENTS.md has $lines lines (limit: 300)"
+          if [ "$lines" -gt 300 ]; then
+            echo "ERROR: AGENTS.md exceeds 300-line limit"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# namespace-lister
+
+Go REST service (`/api/v1/namespaces`) that returns Kubernetes namespaces
+a user has `get` access on, using in-memory RBAC caching for performance.
+
+## Quick Commands
+
+| Action            | Command                                    |
+|-------------------|--------------------------------------------|
+| Build             | `go build -o bin/namespace-lister .`       |
+| Unit tests        | `make test`                                |
+| Performance tests | `make test-perf`                           |
+| Acceptance tests  | `make -C acceptance/test/dumb-proxy prepare && make -C acceptance/test/dumb-proxy test` |
+| Lint              | `make lint`                                |
+| Format            | `make fmt`                                 |
+
+## Project Layout
+
+- `*.go` (root) — core server: authenticator, RBAC authorizer, HTTP handler,
+  namespace lister, metrics, environment config.
+- `internal/` — `constants`, `contextkey`, `http`, `log`, `resourcecache`.
+- `pkg/` — public packages: `auth`, `metricsutil`.
+- `acceptance/` — godog BDD tests; two setups: `dumb-proxy` and `smart-proxy`.
+- `config/` — Kustomize deployment manifests.
+
+## Key Conventions
+
+- Authentication is out of scope — pre-authenticated headers or bearer token
+  for TokenAccessReview.
+- Ginkgo for unit/perf tests; godog (Cucumber BDD) for acceptance tests.
+- Performance tests use kwokctl for lightweight cluster simulation.
+- golangci-lint version pinned in Makefile (`GOLANGCI_LINT_VERSION`).
+- Coverage instrumentation toggled via `ENABLE_COVERAGE=true`.
+- All changes via PR; OWNERS approval required.
+
+## Testing
+
+- **Unit tests**: Ginkgo-based, run with `make test`. Cover RBAC logic,
+  HTTP handlers, authenticator, and metrics.
+- **Performance tests**: Ginkgo with kwokctl cluster. Require kwokctl.
+- **Acceptance tests**: godog BDD with Kind cluster. Two setups: `dumb-proxy`
+  (direct) and `smart-proxy` (behind proxy). `make prepare` builds image,
+  creates Kind cluster, and deploys all components.
+- Coverage collected via coverport-cli and uploaded to Codecov.
+
+## CI Pipeline (GitHub Actions)
+
+- `unit-tests` — Ginkgo tests with coverage, uploads to Codecov.
+- `performance-tests` — perf tests with kwokctl.
+- `acceptance` — matrix of `dumb-proxy`/`smart-proxy` on Kind, e2e coverage.
+- `go-tidy` — verifies `go.mod` and `go.sum` are tidy.
+- `lint-go` — golangci-lint (version from Makefile).
+- `lint-yaml` — yamllint on all YAML manifests.
+- `dep-triage` — auto-triages Renovate/Konflux bot dependency PRs.
+- `auto-merge` — merges approved dependency PRs when all checks pass.
+
+## Gotchas
+
+- Acceptance tests build/load a container image into Kind — requires Docker
+  or Podman (`IMAGE_BUILDER` variable).
+- Both `dumb-proxy` and `smart-proxy` acceptance setups must pass — they
+  test different authentication flows.
+- Coverage collection requires coverport-cli and a running instrumented pod.


### PR DESCRIPTION
Add agent instructions following the infra team AGENTS.md template: project description, quick commands, layout, conventions, testing, CI pipeline, and gotchas. Add GitHub Actions workflow to enforce the 300-line limit on AGENTS.md changes.

Closes: KFLUXINFRA-3735