### PR TITLE
prevent unintended execution of perf test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-perf: ## Run performance tests
 	-$(PERF_CLUSTER_PROVIDER) delete cluster --name namespace-lister-perf-test
 	KUBECONFIG=$(PERF_CLUSTER_KUBECONFIG) $(PERF_CLUSTER_PROVIDER) create cluster \
 		--name namespace-lister-perf-test $(PERF_CLUSTER_PROVIDER_FLAGS)
-	KUBECONFIG=$(PERF_CLUSTER_KUBECONFIG) $(GINKGO) --label-filter='perf' \
+	KUBECONFIG=$(PERF_CLUSTER_KUBECONFIG) $(GINKGO) --tags='perf' --label-filter='perf' \
 		--keep-going --procs=1 --flake-attempts 2 --output-dir=$(PERF_OUT_DIR)
 	# -$(PERF_CLUSTER_PROVIDER) delete cluster --name namespace-lister-perf-test
 

--- a/performance_test.go
+++ b/performance_test.go
@@ -1,3 +1,5 @@
+//go:build perf
+
 package main
 
 import (
@@ -37,7 +39,7 @@ const (
 	NamespaceTypeUserLabelValue string = "user"
 )
 
-var _ = Describe("Authorizing requests", Serial, Ordered, func() {
+var _ = Describe("Authorizing requests", Serial, Ordered, Label("perf"), func() {
 	username := "user"
 	var restConfig *rest.Config
 	var c client.Client
@@ -75,7 +77,7 @@ var _ = Describe("Authorizing requests", Serial, Ordered, func() {
 		cacheCfg = &resourcecache.Config{RestConfig: restConfig, NamespacesLabelSelector: ls}
 	})
 
-	It("efficiently authorize on a huge environment with cached accesses", Serial, Label("perf"), func(ctx context.Context) {
+	It("efficiently authorize on a huge environment with cached accesses", Serial, func(ctx context.Context) {
 		// new gomega experiment
 		experiment := gmeasure.NewExperiment("Authorizing Request")
 


### PR DESCRIPTION
We want to prevent unintended execution of performance test via `go test ./...`.
With this change it will require to set `--tags=perf`.

Signed-off-by: Francesco Ilario <filario@redhat.com>
