### PR TITLE
KFLUXINFRA-3773 add agent skills for PR workflow, CI troubleshooting, and brainstorming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,9 @@ a user has `get` access on, using in-memory RBAC caching for performance.
 - Both `dumb-proxy` and `smart-proxy` acceptance setups must pass — they
   test different authentication flows.
 - Coverage collection requires coverport-cli and a running instrumented pod.
+
+## Skills
+
+- Before opening a PR, writing a PR description, or interpreting CI results, read `skills/pr-workflow.md`
+- When a CI check fails on a PR, read `skills/ci-troubleshooting.md`
+- When working interactively on new features or significant changes, read `skills/brainstorming-workflow.md` before making changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/skills/brainstorming-workflow.md
+++ b/skills/brainstorming-workflow.md
@@ -1,0 +1,67 @@
+---
+name: brainstorming-workflow
+description: >
+  Use when in an interactive session and the user requests a new feature, significant
+  change, refactor, or architectural decision in namespace-lister. Provides a structured
+  process choice before any changes are made. Skip when dispatched with a complete task.
+---
+
+# Brainstorming Workflow
+
+Discipline for interactive sessions involving new features, refactors, performance optimizations, API changes, or other significant changes.
+
+## Context Detection
+
+- **Interactive session** (human in CLI/IDE): follow this workflow.
+- **Dispatched with a complete task** (sub-agent, automation, explicit spec): skip entirely and execute.
+
+## First Message
+
+Before making any changes, ask exactly ONE question:
+
+> I can approach this a few ways:
+>
+> A) Jump straight to making changes
+> B) Discuss approaches first, then make changes
+> C) Full design process — explore approaches, write up a plan, then execute
+>
+> Which works for you?
+
+**Always ask this question first**, even when the request sounds urgent. It's a quick check that keeps things on track.
+
+**After asking**, if the human replies with "just do it", gives a direct instruction, or otherwise signals urgency, treat as **A**. But ask first — don't skip the question based on tone or urgency cues in the initial request.
+
+## Path A — Jump to Changes
+
+Proceed directly. All existing conventions still apply (pr-workflow, testing requirements). No additional ceremony.
+
+## Path B — Discuss Approaches
+
+1. **Understand the problem**: what is being changed, why, and any constraints.
+2. **Propose 2-3 approaches** with trade-offs (complexity, test coverage impact, performance implications, API compatibility).
+3. **Lead with a recommendation** and explain why.
+4. Let the human choose, then execute.
+
+namespace-lister examples where this helps:
+- Choosing between adding a new HTTP handler vs extending an existing one
+- Deciding how to restructure RBAC caching logic for a new authorization requirement
+- Planning how to add a new metric or observability signal
+- Evaluating whether a change needs new acceptance test scenarios or unit tests are sufficient
+- Designing a new internal package vs extending an existing one in `internal/` or `pkg/`
+
+Ask one question at a time. Prefer multiple choice over open-ended questions.
+
+## Path C — Full Design Process
+
+Everything in Path B, plus:
+
+1. **Write up the plan** — what changes in which files/packages, test strategy, API impact.
+2. **Break into ordered steps** with dependencies (e.g., add types first, then handler, then tests).
+3. Get human approval before executing.
+
+## Key Principles
+
+- **One question at a time.** Never pile up multiple questions in one message.
+- **Prefer multiple choice.** Easier for the human to decide quickly.
+- **Human decides the process, not the agent.** Respect the chosen path.
+- **"Just do it" means just do it.** Don't add process the human didn't ask for.

--- a/skills/ci-troubleshooting.md
+++ b/skills/ci-troubleshooting.md
@@ -74,7 +74,7 @@ make test-perf
 
 ### acceptance
 
-Matrix of `dumb-proxy` and `smart-proxy` acceptance test setups running on Kind clusters with godog (Cucumber BDD). Both setups must pass.
+Matrix of `dumb-proxy` and `smart-proxy` acceptance test setups running on Kind clusters with [cucumber/godog](https://github.com/cucumber/godog) (BDD). Both setups must pass.
 
 Common causes of failure:
 - Container image build failure (check Podman/Docker availability)
@@ -84,8 +84,8 @@ Common causes of failure:
 To reproduce locally:
 
 ```bash
-make -C acceptance/test/dumb-proxy prepare && make -C acceptance/test/dumb-proxy test
-make -C acceptance/test/smart-proxy prepare && make -C acceptance/test/smart-proxy test
+make -C acceptance/test/dumb-proxy prepare test
+make -C acceptance/test/smart-proxy prepare test
 ```
 
 If logs show no relevant errors and the failure looks intermittent, rerun the failed job:

--- a/skills/ci-troubleshooting.md
+++ b/skills/ci-troubleshooting.md
@@ -61,7 +61,7 @@ make test
 If a specific test is failing, run it in isolation:
 
 ```bash
-go run github.com/onsi/ginkgo/v2/ginkgo --focus "description of failing test" ./...
+GINKGO_ARGS='--focus="description of failing test"' make test
 ```
 
 ### performance-tests

--- a/skills/ci-troubleshooting.md
+++ b/skills/ci-troubleshooting.md
@@ -1,0 +1,128 @@
+---
+name: ci-troubleshooting
+description: >
+  Use when a CI check fails on a PR in namespace-lister and you need to
+  understand what failed, how to read the logs, and how to fix it.
+---
+
+# CI Troubleshooting
+
+## Overview
+
+How to investigate and fix CI failures on namespace-lister PRs.
+
+## When to Use
+
+- A CI check failed on your PR
+- You need to understand what a CI comment or status means
+- You want to re-trigger a flaky test
+
+## Prerequisites
+
+Verify `gh` CLI is installed and authenticated:
+
+```bash
+gh auth status
+```
+
+All CI investigation commands below depend on it.
+
+## Reading CI Logs
+
+### GitHub Actions checks
+
+```bash
+gh pr checks <PR-number> --repo konflux-ci/namespace-lister
+```
+
+To investigate a failed check:
+
+```bash
+gh run view <run-id> --repo konflux-ci/namespace-lister
+gh run view <run-id> --repo konflux-ci/namespace-lister --log-failed
+```
+
+### Tekton / Konflux pipeline checks
+
+Tekton pipeline runs (pull-request and push pipelines defined in `.tekton/`) execute inside the Konflux platform. These are best investigated manually through the Konflux UI.
+
+If a Tekton pipeline check fails, you can comment `/retest` on the PR to re-trigger, but if the failure persists, escalate to a human who can inspect the logs in the Konflux UI.
+
+## Common Failures
+
+### unit-tests
+
+Ginkgo test failures. The GitHub Actions log shows which specs failed and the failure messages. To reproduce locally:
+
+```bash
+make test
+```
+
+If a specific test is failing, run it in isolation:
+
+```bash
+go run github.com/onsi/ginkgo/v2/ginkgo --focus "description of failing test" ./...
+```
+
+### performance-tests
+
+Ginkgo performance tests using kwokctl. These require kwokctl to be installed. If failed, check if it's a flaky infrastructure issue (kwokctl cluster setup) or a real regression. To reproduce locally:
+
+```bash
+make test-perf
+```
+
+### acceptance
+
+Matrix of `dumb-proxy` and `smart-proxy` acceptance test setups running on Kind clusters with godog (Cucumber BDD). Both setups must pass.
+
+Common causes of failure:
+- Container image build failure (check Podman/Docker availability)
+- Kind cluster setup failure (infrastructure flake — rerun)
+- Actual test scenario failure (check the godog output for the failing step)
+
+To reproduce locally:
+
+```bash
+make -C acceptance/test/dumb-proxy prepare && make -C acceptance/test/dumb-proxy test
+make -C acceptance/test/smart-proxy prepare && make -C acceptance/test/smart-proxy test
+```
+
+If logs show no relevant errors and the failure looks intermittent, rerun the failed job:
+
+```bash
+gh run rerun <run-id> --repo konflux-ci/namespace-lister --failed
+```
+
+### go-tidy
+
+`go.mod` or `go.sum` are not tidy. Fix:
+
+```bash
+go mod tidy
+```
+
+Then commit the changes.
+
+### lint-go
+
+golangci-lint violations. The log shows the exact file, line, and linter rule. Fix the reported issues or run locally:
+
+```bash
+make lint-go
+```
+
+### lint-yaml
+
+YAML formatting errors (trailing whitespace, wrong indentation, missing newline at end of file). Fix the reported issues or run locally:
+
+```bash
+make lint-yaml
+```
+
+### Tekton pipeline failures
+
+The `.tekton/` pipelines run security scans (Clair, Snyk, Coverity, ClamAV, SAST) and multi-arch container builds. These run inside Konflux and their logs are not accessible from the CLI. If they fail:
+
+1. Comment `/retest` on the PR to re-trigger.
+2. If the failure persists, these are best investigated manually through the Konflux UI by a human.

--- a/skills/pr-workflow.md
+++ b/skills/pr-workflow.md
@@ -1,0 +1,113 @@
+---
+name: pr-workflow
+description: >
+  Use when opening, monitoring, or iterating on a pull request in namespace-lister,
+  including PR body template, CI interpretation, and commit conventions.
+---
+
+# PR Workflow
+
+Full lifecycle reference for pull requests in the namespace-lister repository.
+
+## Overview
+
+namespace-lister is a Go REST service that returns Kubernetes namespaces a user has access to. PRs target `main` on the upstream repository.
+
+## When to Use
+
+- About to open a PR or write a PR description
+- Iterating on a PR based on review feedback
+- Preparing commits for a change
+
+## Branch Setup
+
+If a dedicated branch already exists for this work, use it. Otherwise, create a branch from the latest main of `konflux-ci/namespace-lister`.
+
+First, find which remote points to `konflux-ci/namespace-lister`:
+
+```bash
+git remote -v | grep konflux-ci/namespace-lister
+```
+
+Then fetch and branch from it:
+
+```bash
+git fetch <remote>
+git checkout -b <branch-name> <remote>/main --no-track
+```
+
+Common setups: fork-based workflows typically name it `upstream`, while direct clones use `origin`.
+
+Never branch from an old or diverged main.
+
+## PR Body Template
+
+Every PR follows this structure:
+
+```markdown
+## What
+
+<concise list of what changed>
+
+[KFLUXINFRA-1234](https://redhat.atlassian.net/browse/KFLUXINFRA-1234)
+
+## Why
+
+<motivation — why this change is needed>
+
+## Testing
+
+- <which tests cover this change and their results>
+- <e.g., "Added Ginkgo specs for the new handler — `make test` passes">
+- <e.g., "Existing acceptance tests in dumb-proxy/smart-proxy cover this path — both pass">
+```
+
+**Rules:**
+- **What** — Concise change list and Jira link. Don't explain why here.
+- **Why** — Motivation only. Keep it brief.
+- **Testing** — Show that appropriate tests were run and passed. This can be new tests you added or existing tests that cover the change. Reference the specific test type (unit, performance, acceptance) and confirm they pass.
+
+## Commit Conventions
+
+Prefix every commit with the Jira key:
+
+```
+KFLUXINFRA-1234 short description of the change
+```
+
+Always use `-s` flag (DCO sign-off).
+
+Trailers (at end of commit message body). Use the actual agent/tool identity:
+- Interactive sessions (human + agent): `Assisted-by:` trailer
+- Agentic workflow (autonomous): `Authored-by:` trailer
+
+## Key CI Checks
+
+| Check | What It Does |
+|-------|--------------|
+| **unit-tests** | Ginkgo tests with coverage, uploads to Codecov. |
+| **performance-tests** | Ginkgo perf tests with kwokctl. |
+| **acceptance** | Matrix of `dumb-proxy`/`smart-proxy` godog BDD tests on Kind clusters with e2e coverage. |
+| **go-tidy** | Verifies `go.mod` and `go.sum` are tidy. |
+| **lint-go** | golangci-lint with version pinned in Makefile. |
+| **lint-yaml** | yamllint on all YAML manifests. |
+| **Tekton pipelines** | Multi-arch container builds and security scans (Clair, Snyk, Coverity, ClamAV). Run inside Konflux — best investigated manually through the Konflux UI. |
+
+**CI caveats:**
+- Acceptance tests can be flaky due to Kind cluster setup — if logs show no relevant errors, rerun with `gh run rerun <run-id> --failed`.
+- Tekton pipeline failures are best investigated manually through the Konflux UI. Use `/retest` to re-trigger, but don't try to diagnose these yourself.
+
+## Interactive Sessions
+
+In interactive sessions (human + agent), always confirm with the human before pushing and opening the PR. Show them the commit message, PR title, and PR body for approval first. Never push or create a PR without explicit approval.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Not running tests before pushing | Run `make test` and `make lint` locally, mention results in Testing |
+| Putting explanation in Testing instead of evidence | Testing = which tests ran and passed. Why = explanation. |
+| Branching from a stale main | Always fetch and reset from origin before branching |
+| Missing Jira key in commit message | Prefix every commit with `KFLUXINFRA-1234` |
+| Forgetting to run both acceptance setups | Both `dumb-proxy` and `smart-proxy` must pass |
+| Running tests with `go test ./...` | Always use `make test` — this project uses Ginkgo, not plain `go test` |

--- a/skills/pr-workflow.md
+++ b/skills/pr-workflow.md
@@ -110,4 +110,5 @@ In interactive sessions (human + agent), always confirm with the human before pu
 | Branching from a stale main | Always fetch and reset from origin before branching |
 | Missing Jira key in commit message | Prefix every commit with `KFLUXINFRA-1234` |
 | Forgetting to run both acceptance setups | Both `dumb-proxy` and `smart-proxy` must pass |
-| Running tests with `go test ./...` | Always use `make test` — this project uses Ginkgo, not plain `go test` |
+| Running tests with `go test ./...` | Always use `make test` — it wraps Ginkgo with the project's preferred flags and configuration |
+| Forgetting to run perf tests locally | Run `make test-perf` before pushing performance-sensitive changes |


### PR DESCRIPTION
## What

- Add `CLAUDE.md` pointing to `AGENTS.md`
- Add three agent skills under `skills/`: `pr-workflow`, `ci-troubleshooting`, `brainstorming-workflow`
- Add Skills section to `AGENTS.md` pointing to each skill

[KFLUXINFRA-3773](https://redhat.atlassian.net/browse/KFLUXINFRA-3773)

## Why

Codify existing team conventions (PR template, CI investigation steps, design process)
as discoverable agent skills so coding agents follow them consistently.

## Testing

- Skills tested via TDD subagent pressure scenarios (baseline without skill, then with skill loaded)
- `brainstorming-workflow` refined after testing revealed an urgency-bypass loophole — agents skipped the A/B/C process question when requests sounded urgent

[KFLUXINFRA-3773]: https://redhat.atlassian.net/browse/KFLUXINFRA-3773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ