### PR TITLE
Pin kind version and node image in E2E workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,8 +102,13 @@ jobs:
           go-version: ${{ steps.go_version.outputs.version }}
 
       - name: Install pinned kind version
+        # Renovate updates KIND_VERSION automatically; only stable releases are proposed.
+        # If kind and node image are updated independently a version mismatch may cause
+        # cluster creation to fail, which CI will catch before merge.
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION=v0.32.0
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,12 @@ jobs:
         with:
           go-version: ${{ steps.go_version.outputs.version }}
 
+      - name: Install pinned kind version
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
       - name: Run tests
         env:
           KIND_EXPERIMENTAL_PROVIDER: podman

--- a/acceptance/make/common.mk
+++ b/acceptance/make/common.mk
@@ -1,5 +1,6 @@
 KIND_CLUSTER_NAME ?= namespace-lister-acceptance-tests
-KIND_NODE_IMAGE ?= kindest/node:v1.35.5 # renovate: datasource=docker depName=kindest/node versioning=docker
+# renovate: datasource=docker depName=kindest/node versioning=docker
+KIND_NODE_IMAGE ?= kindest/node:v1.35.5
 IMG ?= namespace-lister:latest
 IMAGE_BUILDER ?= docker
 

--- a/acceptance/make/common.mk
+++ b/acceptance/make/common.mk
@@ -32,7 +32,7 @@ image-build:
 
 .PHONY: kind-create
 kind-create:
-	$(KIND) create cluster --name "$(KIND_CLUSTER_NAME)" --config kind-config.yaml --image $(KIND_NODE_IMAGE)
+	$(KIND) create cluster --name "$(KIND_CLUSTER_NAME)" --config kind-config.yaml --image "$(KIND_NODE_IMAGE)"
 
 .PHONY: kind-load-image
 kind-load-image:

--- a/acceptance/make/common.mk
+++ b/acceptance/make/common.mk
@@ -1,4 +1,5 @@
 KIND_CLUSTER_NAME ?= namespace-lister-acceptance-tests
+# renovate: datasource=docker depName=kindest/node versioning=docker
 KIND_NODE_IMAGE ?= kindest/node:v1.35.5
 IMG ?= namespace-lister:latest
 IMAGE_BUILDER ?= docker

--- a/acceptance/make/common.mk
+++ b/acceptance/make/common.mk
@@ -1,4 +1,5 @@
 KIND_CLUSTER_NAME ?= namespace-lister-acceptance-tests
+KIND_NODE_IMAGE ?= kindest/node:v1.35.5
 IMG ?= namespace-lister:latest
 IMAGE_BUILDER ?= docker
 
@@ -31,7 +32,7 @@ image-build:
 
 .PHONY: kind-create
 kind-create:
-	$(KIND) create cluster --name "$(KIND_CLUSTER_NAME)" --config kind-config.yaml
+	$(KIND) create cluster --name "$(KIND_CLUSTER_NAME)" --config kind-config.yaml --image $(KIND_NODE_IMAGE)
 
 .PHONY: kind-load-image
 kind-load-image:

--- a/acceptance/make/common.mk
+++ b/acceptance/make/common.mk
@@ -1,6 +1,5 @@
 KIND_CLUSTER_NAME ?= namespace-lister-acceptance-tests
-# renovate: datasource=docker depName=kindest/node versioning=docker
-KIND_NODE_IMAGE ?= kindest/node:v1.35.5
+KIND_NODE_IMAGE ?= kindest/node:v1.35.5 # renovate: datasource=docker depName=kindest/node versioning=docker
 IMG ?= namespace-lister:latest
 IMAGE_BUILDER ?= docker
 

--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,28 @@
       "matchStrings": [
         "#\\s+?renovate:\\s+?datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s+?.+?_VERSION\\s+?\\?=\\s+?(?<currentValue>.+?)\\s"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update kind binary version in CI workflows",
+      "managerFilePatterns": [
+        ".github/workflows/**"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\n\\s*KIND_VERSION=(?<currentValue>v[^\\s]+)"
+      ],
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kind node image in CI workflows and Makefiles",
+      "managerFilePatterns": [
+        ".github/workflows/**",
+        "**/common.mk"
+      ],
+      "matchStrings": [
+        "kindest/node:(?<currentValue>v[^\\s#]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,7 @@
         "minor",
         "patch",
         "digest"
-      ],
+      ]
     },
     {
       "groupName": "go-modules major",
@@ -61,7 +61,7 @@
         "minor",
         "major",
         "digest"
-      ],
+      ]
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -102,7 +102,8 @@
         "**/common.mk"
       ],
       "matchStrings": [
-        "kindest/node:(?<currentValue>v[^\\s#]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)"
+        "kindest/node:(?<currentValue>v[^\\s#]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)",
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)\\n[A-Z_]+\\s*\\?=\\s*kindest/node:(?<currentValue>v[^\\s#]+)"
       ]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,14 @@
         "major",
         "digest"
       ]
+    },
+    {
+      "groupName": "kind cluster tooling",
+      "description": "keep kind binary and node image in sync",
+      "matchDepNames": [
+        "kubernetes-sigs/kind",
+        "kindest/node"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Install pinned kind v0.32.0 instead of relying on runner-preinstalled version
- Pin node image to `kindest/node:v1.35.5` via Makefile variable
- Add Renovate annotations so both versions are kept up to date automatically

## Root cause
Runner-preinstalled kind or `kind.sigs.k8s.io/dl/latest/` can resolve to alpha builds (e.g. `v0.33.0-alpha`) shipping `kindest/node:v1.36.1`, whose OCI runtime spec version is incompatible with the `crun` binary on GitHub Actions ubuntu runners when `KIND_EXPERIMENTAL_PROVIDER=podman`, producing `crun: unknown version specified` (exit 126) at cluster creation.

## Approach
Rather than hardcoding a version that rots, the kind binary version and node image are annotated with Renovate datasource comments:
- **kind binary** (workflow): `datasource=github-releases depName=kubernetes-sigs/kind` — Renovate's default semver versioning excludes pre-release tags (`-alpha`, `-beta`, `-rc`), so only stable kind releases are proposed.
- **node image** (Makefile): `datasource=docker depName=kindest/node` — tracked as a Docker image tag.

Because kind and its node image are not independently versionable, a Renovate update to one without the other could cause a mismatch. This is safe because **CI creates a kind cluster on every PR** — an incompatible pairing fails the acceptance tests before merge, making the mismatch visible and blocking the update.

## Test plan
- [ ] Acceptance tests pass with pinned versions (CI validates this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)