### PR TITLE
KFLUXINFRA-4373 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -14,13 +14,13 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           client-id: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_PRIVATE_KEY }}
-      - uses: konflux-ci/deptriage@main
+      - uses: konflux-ci/deptriage@bfae36b5ef9ca2bf959fcf54465a7f965d0afe8c # main
         with:
           command: merge
           head-sha: ${{ github.event.check_suite.head_sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Determine Go version
         id: go_version
@@ -26,7 +26,7 @@ jobs:
           echo "version=$(go mod edit -json | jq -r '.Go')" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ steps.go_version.outputs.version }}
 
@@ -37,7 +37,7 @@ jobs:
         run: make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           use_oidc: true
           flags: unit-tests
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Determine Go version
         id: go_version
@@ -58,16 +58,16 @@ jobs:
           echo "version=$(go mod edit -json | jq -r '.Go')" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ steps.go_version.outputs.version }}
 
-      - uses: kubernetes-sigs/kwok@main
+      - uses: kubernetes-sigs/kwok@172defa550f15c9ffd4169896c32bba4770f6577 # main
         with:
           command: 'kwokctl'
 
       - name: Set up kwokctl
-        uses: kubernetes-sigs/kwok@main
+        uses: kubernetes-sigs/kwok@172defa550f15c9ffd4169896c32bba4770f6577 # main
         with:
           command: kwokctl
 
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Determine Go version
         id: go_version
@@ -97,7 +97,7 @@ jobs:
           echo "version=$(go mod edit -json | jq -r '.Go')" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ steps.go_version.outputs.version }}
 
@@ -148,7 +148,7 @@ jobs:
       - name: Upload e2e coverage to Codecov
         if: steps.collect_e2e_coverage.outcome == 'success'
         id: upload_e2e_coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           use_oidc: true
           flags: e2e-tests
@@ -162,10 +162,10 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
 
@@ -192,10 +192,10 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: ./go.mod
 
@@ -206,7 +206,7 @@ jobs:
             >> $GITHUB_OUTPUT
 
       - name: Lint with golang-ci
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: ${{ steps.golangci_version.outputs.version }}
           args: --timeout=5m
@@ -221,7 +221,7 @@ jobs:
           pip install yamllint
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Lint with yamllint
         run: make lint-yaml

--- a/.github/workflows/dep-triage.yaml
+++ b/.github/workflows/dep-triage.yaml
@@ -22,8 +22,8 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: konflux-ci/deptriage@main
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: konflux-ci/deptriage@bfae36b5ef9ca2bf959fcf54465a7f965d0afe8c # main
         with:
           command: both
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -41,7 +41,7 @@ jobs:
     if: >-
       github.event_name != 'issue_comment'
       || github.event.comment.user.type != 'Bot'
-    uses: konflux-ci/.fullsend/.github/workflows/dispatch.yml@main
+    uses: konflux-ci/.fullsend/.github/workflows/dispatch.yml@701e62a9c6f104ed68f8d4085d9c3b8bad3a82e4 # main
     with:
       event_action: ${{ github.event.action }}
 


### PR DESCRIPTION
## What

Pin all GitHub Actions `uses:` references to immutable commit SHAs (with version comments for readability).

| Action | SHA | Tag |
|--------|-----|-----|
| `actions/checkout` | `d23441a48e516b6c34aea4fa41551a30e30af803` | v6 |
| `actions/setup-go` | `924ae3a1cded613372ab5595356fb5720e22ba16` | v6 |
| `actions/create-github-app-token` | `bcd2ba49218906704ab6c1aa796996da409d3eb1` | v3 |
| `codecov/codecov-action` | `fb8b3582c8e4def4969c97caa2f19720cb33a72f` | v6 |
| `golangci/golangci-lint-action` | `ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a` | v9 |
| `kubernetes-sigs/kwok` | `172defa550f15c9ffd4169896c32bba4770f6577` | main |
| `konflux-ci/deptriage` | `bfae36b5ef9ca2bf959fcf54465a7f965d0afe8c` | main |
| `konflux-ci/.fullsend/.../dispatch.yml` | `701e62a9c6f104ed68f8d4085d9c3b8bad3a82e4` | main |

Files updated: `ci.yaml`, `auto-merge.yaml`, `dep-triage.yaml`, `fullsend.yaml`.

Already pinned (unchanged): `agents-md-lint.yaml`, `lint-renovate.yml`, `coverport-cli` container image.

## Why

Floating version tags and branch refs can change without notice, creating supply-chain risk. Pinning to commit SHAs ensures workflows run the exact code we reviewed.

## Testing

- Workflow-only change; CI will validate on this PR.

Made with [Cursor](https://cursor.com)